### PR TITLE
feat(auth-exception): 구글 로그인중 약관 동의 취소시 예외처리 추가

### DIFF
--- a/back-end/src/auth/auth-exception.filter.ts
+++ b/back-end/src/auth/auth-exception.filter.ts
@@ -1,0 +1,12 @@
+import { Catch, ExceptionFilter, ArgumentsHost, UnauthorizedException } from '@nestjs/common';
+
+@Catch(UnauthorizedException)
+export class AuthExceptionFilter implements ExceptionFilter {
+  catch(exception: UnauthorizedException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    
+    // 인증 실패 시 4000 포트로 리디렉션
+    response.redirect('http://localhost:4000');
+  }
+}

--- a/back-end/src/auth/auth.controller.ts
+++ b/back-end/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Request, Response, UseGuards } from '@nestjs/common';
+import { Controller, Get, Request, Response, UseFilters, UseGuards } from '@nestjs/common';
 
 import { GoogleAuthGuard } from './auth.guard';
+import { AuthExceptionFilter } from './auth-exception.filter';
 
 @Controller('auth')
 export class AuthController {
@@ -19,6 +20,7 @@ export class AuthController {
 
   @Get('google')
   @UseGuards(GoogleAuthGuard)
+  @UseFilters(AuthExceptionFilter) // 예외 처리기 적용
   async googleAuthRedirect(@Request() req, @Response() res) {
     const { user } = req;
     if (user) {


### PR DESCRIPTION
## 관련 이슈
- 이 PR이 해결하는 이슈 번호: #<이슈 번호>

## 변경 사항
- 구글 로그인중 약관 동의 취소시 예외처리 추가
- 약관 동의 취소시 리액트 홈(4000port)로 리디렉션
## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- PR 작성 시 알릴 다른 중요한 내용이 있으면 적어주세요.
