### PR TITLE
bug(upload-profile): 서버에서 프로파일 이미지 저장시 파일명 인코딩 문제 수정

### DIFF
--- a/back-end/src/main.ts
+++ b/back-end/src/main.ts
@@ -4,6 +4,8 @@ import { ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import * as session from 'express-session';
 import * as passport from 'passport';
+import * as express from 'express';
+import { join } from 'path';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -19,6 +21,7 @@ async function bootstrap() {
   );
   app.use(passport.initialize());
   app.use(passport.session());
+  app.use('/uploads', express.static(join(__dirname, '..', 'uploads')));
   app.enableCors({
     origin: 'http://localhost:4000', // 클라이언트 도메인을 React의 포트인 4000번으로 설정
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS', // 허용할 HTTP 메서드 명시

--- a/back-end/src/user/user.service.ts
+++ b/back-end/src/user/user.service.ts
@@ -55,9 +55,9 @@ export class UserService {
 
     // 파일이 있는 경우에만 프로필 이미지 URL 업데이트
     if (file) {
-      const encodedFileName = encodeURIComponent(file.originalname);
-      const uniqueFilename = `${uuidv4()}-${encodedFileName}`;
+      const uniqueFilename = `${uuidv4()}.png`;
       const newPath = `./uploads/${uniqueFilename}`;
+     
 
       if (!fs.existsSync('./uploads')) {
         fs.mkdirSync('./uploads');


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- 서버에서 프로파일 이미지 저장 시 파일 이름 인코딩 문제 수정
- 특수 문자가 이미지 경로에 저장되지 않게 하기 위해 uuid형식으로 저장하도록 수정 

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
