### PR TITLE
feat: 게시글 파일 업로드 기능 추가 및 기본 카테고리 적용

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -13,6 +13,7 @@ import { Post } from './posts/entities/post.entity';
 import { Category } from './posts/entities/category.entity';
 import { Like } from './posts/entities/like.entity';
 import { Comment } from './posts/entities/comment.entity';
+import { UploadModule } from './upload/upload.module';
 
 
 @Module({
@@ -30,6 +31,7 @@ import { Comment } from './posts/entities/comment.entity';
     ResumeModule,
     ContactModule,
     PostsModule,
+    UploadModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/back-end/src/posts/category.service.ts
+++ b/back-end/src/posts/category.service.ts
@@ -22,6 +22,7 @@ export class CategoryService implements OnModuleInit {
       { ㅍcategory: '정보게시판' },
       { category: '공지사항' },
       { category: '문의하기' },
+      { category: 'default'}
     ];
 
     for (const category of defaultCategories) {

--- a/back-end/src/posts/dto/post/create-post.dto.ts
+++ b/back-end/src/posts/dto/post/create-post.dto.ts
@@ -1,4 +1,4 @@
-import { IsString,  Length } from 'class-validator';
+import { IsInt, IsString, Length, Min } from 'class-validator';
 
 export class CreatePostDto {
   @IsString()
@@ -10,4 +10,8 @@ export class CreatePostDto {
 
   @IsString()
   category: string;
+
+  @IsInt()
+  @Min(1)
+  post_id: number;
 }

--- a/back-end/src/posts/post.http
+++ b/back-end/src/posts/post.http
@@ -21,6 +21,10 @@ GET http://localhost:3000/posts/users/cool102476@naver.com
 GET http://localhost:3000/posts/top?n=5
 
 
+###upload file and get file url
+POST http://localhost:3000/posts/upload
+Content-Type: multipart/form-data
+
 //o
 ### Create a Post
 POST http://localhost:3000/posts

--- a/back-end/src/posts/posts.module.ts
+++ b/back-end/src/posts/posts.module.ts
@@ -10,10 +10,12 @@ import { Post } from './entities/post.entity';
 import { Category } from './entities/category.entity';
 import { Like } from './entities/like.entity';
 import { Comment } from './entities/comment.entity';
+import { UploadService } from 'src/upload/upload.service';
+
 
 @Module({
   imports: [TypeOrmModule.forFeature([Post, Category, User, Like, Comment]), UserModule],
   controllers: [PostsController],
-  providers: [PostsService, CategoryService],
+  providers: [PostsService, CategoryService, UploadService],
 })
 export class PostsModule {}

--- a/back-end/src/upload/upload.module.ts
+++ b/back-end/src/upload/upload.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { UploadService } from './upload.service';
+
+@Module({
+  providers: [UploadService]
+})
+export class UploadModule {}

--- a/back-end/src/upload/upload.service.ts
+++ b/back-end/src/upload/upload.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { extname, join } from 'path';
+
+@Injectable()
+export class UploadService {
+  async uploadFile(
+    file: Express.Multer.File,
+    uploadPath: string,
+    filename?: string,
+  ): Promise<string> {
+    if (!file) {
+      throw new BadRequestException('파일이 제공되지 않았습니다.');
+    }
+
+    if (!existsSync(uploadPath)) {
+      mkdirSync(uploadPath, { recursive: true });
+    }
+
+    const finalFilename =
+      filename ||
+      `${Date.now()}-${Math.round(Math.random() * 1e9)}${extname(file.originalname)}`;
+    const filePath = join(uploadPath, finalFilename);
+
+    writeFileSync(filePath, file.buffer);
+
+    return `http://localhost:3000/uploads/${uploadPath.replace('./uploads/', '')}/${finalFilename}`;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- 게시글 작성 시 파일 업로드 가능하도록 API 구현
- 파일 업로드 시 기본 카테고리 자동 적용
- 업로드된 파일은postId 기반 폴더에 저장
- 파일을 업로드한 후 파일의 URL을 리턴
- 특정 MIME 타입만 허용하여 보안 강화
- AP I 테스트용 HTTP 요청 파일 정리
- 게시글 생성 api 호출 인자 post_id추가

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
