### PR TITLE
Bugfix: 댓글 삭제 API에서 잘못된 파라미터 수정

### DIFF
--- a/back-end/src/posts/entities/comment.entity.ts
+++ b/back-end/src/posts/entities/comment.entity.ts
@@ -1,5 +1,5 @@
 import { User } from "src/user/user.entity";
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { Post } from "./post.entity";
 
 @Entity()
@@ -11,9 +11,11 @@ export class Comment{
     comment:string;
 
     @ManyToOne(()=>User, {nullable:false, onDelete:'CASCADE'})
+    @JoinColumn({name:'user_id'})
     user_id:User;
 
     @ManyToOne(()=>Post, {nullable:false, onDelete:'CASCADE'})
+    @JoinColumn({name:'post_id'})
     post_id:Post;
 
     @ManyToOne(()=>Comment, {nullable:true, onDelete:'CASCADE'})

--- a/back-end/src/posts/posts.controller.ts
+++ b/back-end/src/posts/posts.controller.ts
@@ -221,7 +221,7 @@ export class PostsController {
     );
   }
   // 댓글 삭제
-  @Delete('/comment/:id')
+  @Delete('/comment/:comment_id')
   @UseGuards(AuthenticatedGuard)
   async deleteComment(
     @Param('comment_id', ParseIntPipe) comment_id: number,


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- 댓글 삭제 API에서 잘못된 파라미터 수정 '/comment/:Id' -> '/comment/:comment_id'


## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
