### PR TITLE
Refactor/limit user fields in posts

### DIFF
--- a/back-end/src/posts/posts.service.ts
+++ b/back-end/src/posts/posts.service.ts
@@ -75,27 +75,78 @@ export class PostsService {
   //-----------------------------------post----------------------------------------------------
   // 모든 게시글 조회
   async getAllPosts() {
-    return await this.postRepository.find({ relations: ['user', 'category'] });
+    const posts = await this.postRepository.find({ relations: ['user', 'category'] });
+  
+    const processedPosts = posts.map(post => {
+      const { user } = post;
+      const slimUser = {
+        user_id: user.user_id,
+        email: user.email,
+        name: user.name,
+      };
+  
+      return {
+        ...post,
+        user: slimUser,
+      };
+    });
+  
+    return processedPosts;
   }
+  
 
   // 게시글 ID로 조회
   private async findPostById(post_id: number) {
-    const post = await this.postRepository.findOne({ where: { post_id } });
+    const post = await this.postRepository.findOne({
+      where: { post_id },
+      relations: ['user', 'category'],
+    });
+  
     if (!post) {
       throw new NotFoundException(
         `ID가 ${post_id}인 게시글을 찾을 수 없습니다.`,
       );
     }
-    return post;
+
+    const { user } = post;
+    const slimUser = {
+      user_id: user.user_id,
+      email: user.email,
+      name: user.name,
+    };
+    const result = {
+      ...post,
+      user: slimUser,
+    };
+  
+    return result;
   }
+  
 
   // 유저 아이디로 게시글 조회
   async getPostsByUserId(user_id: number) {
-    return await this.postRepository.find({
+    const posts = await this.postRepository.find({
       where: { user: { user_id } },
       relations: ['user', 'category'],
     });
+  
+    const processedPosts = posts.map(post => {
+      const { user } = post;
+      const slimUser = {
+        user_id: user.user_id,
+        email: user.email,
+        name: user.name,
+      };
+  
+      return {
+        ...post,
+        user: slimUser,
+      };
+    });
+  
+    return processedPosts;
   }
+  
 
   //게시글 파일 업로드드
   async uploadPostFiles(user_id: number, files: Express.Multer.File[]) {


### PR DESCRIPTION
## 관련 이슈
- 이 PR이 해결하는 이슈 번호: #<이슈 번호>

## 변경 사항
게시글 조회 시 포함되는 user 정보에서 불필요한 필드를 제거하고 user_id, email, name만 응답하도록 수정하였습니다.
  -findPostById, getAllPosts, getPostsByUserId 함수에서 동일한 방식으로 user 필드 가공 처리 적용
  -민감하거나 불필요한 유저 정보가 클라이언트에 노출되지 않도록 응답 데이터 구조 최적화

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- PR 작성 시 알릴 다른 중요한 내용이 있으면 적어주세요.
