### PR TITLE
게시글 생성&수정 시 유저 정보, 좋아요 수, 댓글 내용 반환 추가

### DIFF
--- a/back-end/src/posts/posts.service.ts
+++ b/back-end/src/posts/posts.service.ts
@@ -74,25 +74,27 @@ export class PostsService {
       },
     });
 
-    const processedPosts = await Promise.all(posts.map(async(post) => {
-      const { user, post_id } = post;
-      const slimUser = {
-        user_id: user.user_id,
-        email: user.email,
-        name: user.name,
-        profile_image: user.profile_image,
-      };
+    const processedPosts = await Promise.all(
+      posts.map(async (post) => {
+        const { user, post_id } = post;
+        const slimUser = {
+          user_id: user.user_id,
+          email: user.email,
+          name: user.name,
+          profile_image: user.profile_image,
+        };
 
-      const likecount = await this.getLikeCount(post_id);
-      const commentcount = await this.getCommentCount(post_id);
+        const likecount = await this.getLikeCount(post_id);
+        const commentcount = await this.getCommentCount(post_id);
 
-      return {
-        ...post,
-        user: slimUser,
-        likecount: likecount,
-        commentcount: commentcount,
-      };
-    }));
+        return {
+          ...post,
+          user: slimUser,
+          likecount: likecount,
+          commentcount: commentcount,
+        };
+      }),
+    );
 
     return processedPosts;
   }
@@ -104,25 +106,27 @@ export class PostsService {
       relations: ['user', 'category'],
     });
 
-    const processedPosts = await Promise.all(posts.map(async(post) => {
-      const { user, post_id } = post;
-      const slimUser = {
-        user_id: user.user_id,
-        email: user.email,
-        name: user.name,
-        profile_image: user.profile_image,
-      };
+    const processedPosts = await Promise.all(
+      posts.map(async (post) => {
+        const { user, post_id } = post;
+        const slimUser = {
+          user_id: user.user_id,
+          email: user.email,
+          name: user.name,
+          profile_image: user.profile_image,
+        };
 
-      const likecount = await this.getLikeCount(post_id);
-      const commentcount = await this.getCommentCount(post_id);
+        const likecount = await this.getLikeCount(post_id);
+        const commentcount = await this.getCommentCount(post_id);
 
-      return {
-        ...post,
-        user: slimUser,
-        likecount: likecount,
-        commentcount: commentcount,
-      };
-    }));
+        return {
+          ...post,
+          user: slimUser,
+          likecount: likecount,
+          commentcount: commentcount,
+        };
+      }),
+    );
 
     return processedPosts;
   }
@@ -145,25 +149,27 @@ export class PostsService {
       relations: ['user', 'category'],
     });
 
-    const processedPosts = await Promise.all(posts.map(async(post) => {
-      const { user, post_id } = post;
-      const slimUser = {
-        user_id: user.user_id,
-        email: user.email,
-        name: user.name,
-        profile_image: user.profile_image,
-      };
+    const processedPosts = await Promise.all(
+      posts.map(async (post) => {
+        const { user, post_id } = post;
+        const slimUser = {
+          user_id: user.user_id,
+          email: user.email,
+          name: user.name,
+          profile_image: user.profile_image,
+        };
 
-      const likecount = await this.getLikeCount(post_id);
-      const commentcount = await this.getCommentCount(post_id);
+        const likecount = await this.getLikeCount(post_id);
+        const commentcount = await this.getCommentCount(post_id);
 
-      return {
-        ...post,
-        user: slimUser,
-        likecount: likecount,
-        commentcount: commentcount,
-      };
-    }));
+        return {
+          ...post,
+          user: slimUser,
+          likecount: likecount,
+          commentcount: commentcount,
+        };
+      }),
+    );
 
     return processedPosts;
   }
@@ -244,7 +250,24 @@ export class PostsService {
     post.content = content;
     post.category = category;
 
-    return await this.postRepository.save(post);
+    const updatedPost = await this.postRepository.save(post);
+
+    const likecount = await this.getLikeCount(post.post_id);
+    const comments = await this.getComment(post.post_id, 1);
+
+    const slimUser = {
+      user_id: user.user_id,
+      email: user.email,
+      name: user.name,
+      profile_image: user.profile_image,
+    };
+
+    return {
+      ...updatedPost,
+      user: slimUser,
+      likecount,
+      comments,
+    };
   }
 
   // 게시글 삭제
@@ -297,7 +320,24 @@ export class PostsService {
       post.category = category;
     }
 
-    return await this.postRepository.save(post);
+    const updatedPost = await this.postRepository.save(post);
+
+    const likecount = await this.getLikeCount(post.post_id);
+    const comments = await this.getComment(post.post_id, 1);
+    const user = await this.userRepository.findOne({ where: { user_id } });
+    const slimUser = {
+      user_id: user.user_id,
+      email: user.email,
+      name: user.name,
+      profile_image: user.profile_image,
+    };
+
+    return {
+      ...updatedPost,
+      user: slimUser,
+      likecount,
+      comments,
+    };
   }
 
   // 조회수 상위 n개 게시글 조회


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
게시글 생성&수정(createPost, updatePost) 시 사용자 정보, 좋아요 수, 댓글 목록 포함하여 응답 반환하도록 수정
findPostById 함수 리턴값을 가공된 게시글 객체로 변경 (user, likecount, comments 포함)
게시글 응답 구조를 프론트엔드에 맞춰 일관성 있게 통일

## 체크리스트
- [o ] 코드 리뷰를 완료했습니다.
- [o ] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [x ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 