### PR TITLE
feat:커뮤니티 페이지에 게시글 검색 기능 추가

### DIFF
--- a/back-end/src/posts/dto/post/get-search-post.dto.ts
+++ b/back-end/src/posts/dto/post/get-search-post.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class GetSearchPostsDto {
+  @IsString()
+  keyword: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+}

--- a/back-end/src/posts/posts.controller.ts
+++ b/back-end/src/posts/posts.controller.ts
@@ -25,6 +25,7 @@ import { AddCommentDto } from './dto/comment/add-comment.dto';
 import { UpdateCommentDto } from './dto/comment/update-comment.dto';
 import { AuthenticatedGuard } from 'src/auth/auth.guard';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import { GetSearchPostsDto } from './dto/post/get-search-post.dto';
 
 @Controller('posts')
 export class PostsController {
@@ -67,26 +68,37 @@ export class PostsController {
     return await this.postsService.getTopPosts(n);
   }
 
+  //검색어로 게시글 조회
+  @Get('search')
+  async searchPosts(@Query() dto: GetSearchPostsDto) {
+    const { keyword, category } = dto;
+    return this.postsService.searchPosts(keyword, category);
+  }
+
   @Post('/upload')
   @UseGuards(AuthenticatedGuard)
   @UseInterceptors(FileFieldsInterceptor([{ name: 'files', maxCount: 10 }])) // 여러 개 파일 업로드 가능
   async uploadPostFiles(
     @UploadedFiles() files: { files?: Express.Multer.File[] },
-     @Request() req
+    @Request() req,
   ) {
     try {
-    
-    const user = req.user;
+      const user = req.user;
       // 게시글 생성 및 파일 업로드
-      const result = await this.postsService.uploadPostFiles(user.user_id, files.files || []);
+      const result = await this.postsService.uploadPostFiles(
+        user.user_id,
+        files.files || [],
+      );
 
-      return { 
-        message: "파일이 성공적으로 업로드 되었습니다.",
+      return {
+        message: '파일이 성공적으로 업로드 되었습니다.',
         postId: result.postId,
-        fileUrls: result.fileUrls 
+        fileUrls: result.fileUrls,
       };
     } catch (error) {
-      throw new BadRequestException(error instanceof Error ? error.message : "게시글 생성 실패");
+      throw new BadRequestException(
+        error instanceof Error ? error.message : '게시글 생성 실패',
+      );
     }
   }
 
@@ -122,7 +134,6 @@ export class PostsController {
   @Delete('/:id')
   @UseGuards(AuthenticatedGuard)
   async deletePost(@Param('id', ParseIntPipe) id: number) {
-
     return await this.postsService.deletePost(id);
   }
 
@@ -156,7 +167,6 @@ export class PostsController {
   ) {
     const user = req.user;
 
-
     const like = await this.postsService.getLike(user.user_id, post_id);
     return like;
   }
@@ -166,7 +176,6 @@ export class PostsController {
   @UseGuards(AuthenticatedGuard)
   async toggleLike(@Param('id', ParseIntPipe) post_id: number, @Request() req) {
     const user = req.user;
-  
 
     return await this.postsService.toggleLike(user.user_id, post_id);
   }
@@ -179,7 +188,7 @@ export class PostsController {
   ) {
     const comments = await this.postsService.getComment(post_id, page);
     const totalCount = await this.postsService.getCommentCount(post_id);
-    
+
     return { totalCount, comments };
   }
 
@@ -212,7 +221,7 @@ export class PostsController {
     @Request() req,
   ) {
     const user = req.user;
-   
+
     const { comment_id, comment } = updateCommentDto;
     return await this.postsService.updateComment(
       user.user_id,
@@ -228,7 +237,6 @@ export class PostsController {
     @Request() req,
   ) {
     const user = req.user;
-
 
     return await this.postsService.deleteComment(user.user_id, comment_id);
   }

--- a/front-end/src/components/community/CommunityAction.tsx
+++ b/front-end/src/components/community/CommunityAction.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { TextField, InputAdornment, Button, Divider } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
+import { useState } from "react";
 
 interface CommunityActionsProps {
   category: string;
@@ -9,11 +10,28 @@ interface CommunityActionsProps {
 const CommunityAction = ({ category }: CommunityActionsProps) => {
   const location = useLocation();
   const navigate = useNavigate();
-
+  const [keyword, setKeyword] = useState("");
   // 게시물 페이지에서는 안 보이게 설정
   const isPostPage = location.pathname.startsWith("/community/post/");
 
   if (isPostPage) return null;
+
+  const handleSearch = async () => {
+    if (!keyword.trim()) return;
+
+    const response = await fetch(
+      `http://localhost:3000/posts/search?keyword=${encodeURIComponent(
+        keyword
+      )}&category=${encodeURIComponent(category)}`
+    );
+
+    if (!response.ok) {
+      console.error("검색 실패");
+      return;
+    }
+
+    const result = await response.json();
+  };
 
   return (
     <>
@@ -23,6 +41,11 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
           size="small"
           variant="outlined"
           sx={{ flex: 1, backgroundColor: "white" }}
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSearch();
+          }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -31,7 +54,7 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
             ),
           }}
         />
-        <Button variant="contained" sx={{ marginLeft: "1rem" }}>
+        <Button variant="contained" sx={{ marginLeft: "1rem" }} onClick={handleSearch}        >
           검색
         </Button>
       </div>


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
-커뮤니티 페이지에 게시글 검색 기능 추가
-검색어 입력 시 게시글 제목 또는 내용에 해당하는 게시글 목록 조회 API 연동
-GET /posts/search API 호출을 통한 실시간 검색 가능
-Enter 또는 버튼 클릭으로 검색 동작 처리

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
