### PR TITLE
feat:게시글 검색 기능에 검색 범위(type) 필터를 추가하여 제목, 내용, 제목+내용 중 선택 가능하도록 구현

### DIFF
--- a/back-end/src/posts/dto/post/get-search-post.dto.ts
+++ b/back-end/src/posts/dto/post/get-search-post.dto.ts
@@ -1,10 +1,15 @@
 import { IsString, IsOptional } from 'class-validator';
 
 export class GetSearchPostsDto {
-  @IsString()
-  keyword: string;
-
-  @IsOptional()
-  @IsString()
-  category?: string;
-}
+    @IsString()
+    keyword: string;
+  
+    @IsOptional()
+    @IsString()
+    category?: string;
+  
+    @IsOptional()
+    @IsString()
+    type?: 'title' | 'content' | 'all';
+  }
+  

--- a/back-end/src/posts/posts.controller.ts
+++ b/back-end/src/posts/posts.controller.ts
@@ -71,8 +71,8 @@ export class PostsController {
   //검색어로 게시글 조회
   @Get('search')
   async searchPosts(@Query() dto: GetSearchPostsDto) {
-    const { keyword, category } = dto;
-    return this.postsService.searchPosts(keyword, category);
+    const { keyword, category, type } = dto;
+    return this.postsService.searchPosts(keyword, category, type);
   }
 
   @Post('/upload')

--- a/back-end/src/posts/posts.service.ts
+++ b/back-end/src/posts/posts.service.ts
@@ -356,15 +356,23 @@ export class PostsService {
 
 
   //검색어로 게시글 조회
-  async searchPosts(keyword:string, category:string) {
-  
+  async searchPosts(keyword: string, category: string, type: string = 'all') {
     const query = this.postRepository
       .createQueryBuilder('post')
       .leftJoinAndSelect('post.user', 'user')
-      .leftJoinAndSelect('post.category', 'category')
-      .where('post.title LIKE :keyword OR post.content LIKE :keyword', {
+      .leftJoinAndSelect('post.category', 'category');
+  
+    // 🔍 조건 분기
+    if (type === 'title') {
+      query.where('post.title LIKE :keyword', { keyword: `%${keyword}%` });
+    } else if (type === 'content') {
+      query.where('post.content LIKE :keyword', { keyword: `%${keyword}%` });
+    } else {
+      // all or undefined
+      query.where('post.title LIKE :keyword OR post.content LIKE :keyword', {
         keyword: `%${keyword}%`,
       });
+    }
   
     if (category) {
       query.andWhere('category.category = :category', { category });

--- a/front-end/src/components/community/CommunityAction.tsx
+++ b/front-end/src/components/community/CommunityAction.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { TextField, InputAdornment, Button, Divider } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { useState } from "react";
+import { MenuItem, Select } from "@mui/material";
 
 interface CommunityActionsProps {
   category: string;
@@ -11,6 +12,9 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [keyword, setKeyword] = useState("");
+  const [searchType, setSearchType] = useState<"title" | "content" | "all">(
+    "all"
+  );
   // 게시물 페이지에서는 안 보이게 설정
   const isPostPage = location.pathname.startsWith("/community/post/");
 
@@ -20,10 +24,9 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
     if (!keyword.trim()) return;
 
     const response = await fetch(
-      `http://localhost:3000/posts/search?keyword=${encodeURIComponent(
-        keyword
-      )}&category=${encodeURIComponent(category)}`
+      `http://localhost:3000/posts/search?keyword=${encodeURIComponent(keyword)}&category=${encodeURIComponent(category)}&type=${searchType}`
     );
+    
 
     if (!response.ok) {
       console.error("검색 실패");
@@ -31,12 +34,24 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
     }
 
     const result = await response.json();
+    console.log(result);
   };
 
   return (
     <>
       {/* 검색 바 */}
       <div style={{ display: "flex", marginBottom: "1rem" }}>
+        <Select
+          value={searchType}
+          size="small"
+          onChange={(e) => setSearchType(e.target.value as any)}
+          sx={{ marginRight: "1rem", width: "140px", backgroundColor: "white" }}
+        >
+          <MenuItem value="title">제목</MenuItem>
+          <MenuItem value="content">내용</MenuItem>
+          <MenuItem value="all">제목+내용</MenuItem>
+        </Select>
+
         <TextField
           size="small"
           variant="outlined"
@@ -54,7 +69,11 @@ const CommunityAction = ({ category }: CommunityActionsProps) => {
             ),
           }}
         />
-        <Button variant="contained" sx={{ marginLeft: "1rem" }} onClick={handleSearch}        >
+        <Button
+          variant="contained"
+          sx={{ marginLeft: "1rem" }}
+          onClick={handleSearch}
+        >
           검색
         </Button>
       </div>


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- 게시글 검색 시 `type`(제목/내용/제목+내용) 파라미터 추가
- 프론트엔드 드롭다운 UI 추가로 검색 범위 선택 가능
- 백엔드에서 type 값에 따라 검색 조건 분기 처리

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ x] 문서를 업데이트했습니다.

## 기타 참고 사항
- 