### PR TITLE
feat:이력서 및 관련 엔티티 설계 및 생성 IntroductionModel, ProjectOutcomeModel, Pro…

### DIFF
--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^10.4.5",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.6",
         "@nestjs/typeorm": "^10.0.2",
@@ -1813,6 +1814,25 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.4.5",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.6",
     "@nestjs/typeorm": "^10.0.2",

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -14,6 +14,13 @@ import { Post } from './posts/entities/post.entity';
 import { Category } from './posts/entities/category.entity';
 import { Like } from './posts/entities/like.entity';
 import { Comment } from './posts/entities/comment.entity';
+import { CommonModule } from './common/common.module';
+import { BaseModel } from './common/entity/base.entity';
+import { IntroductionModel } from './resume/entities/introduction.entity';
+import { ProjectModel } from './resume/entities/project.entity';
+import { SkillModel } from './resume/entities/skill.entity';
+import { ResumeModel } from './resume/entities/resume.entity';
+import { ProjectOutcomeModel } from './resume/entities/project-outcome.entity';
 
 
 
@@ -27,7 +34,7 @@ import { Comment } from './posts/entities/comment.entity';
       username: process.env.DB_USERNAME, 
       password: process.env.DB_PASSWORD, 
       database: process.env.DB_DATABASE, 
-      entities: [User, Post, Category, Like, Comment],
+      entities: [User, Post, Category, Like, Comment, BaseModel,IntroductionModel, ProjectModel, SkillModel, ResumeModel, ProjectOutcomeModel],
       autoLoadEntities: true,
       synchronize: process.env.DB_SYNC === 'true', 
     }),
@@ -37,6 +44,7 @@ import { Comment } from './posts/entities/comment.entity';
     ContactModule,
     PostsModule,
     UploadModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/back-end/src/common/common.controller.spec.ts
+++ b/back-end/src/common/common.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonController } from './common.controller';
+import { CommonService } from './common.service';
+
+describe('CommonController', () => {
+  let controller: CommonController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommonController],
+      providers: [CommonService],
+    }).compile();
+
+    controller = module.get<CommonController>(CommonController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/back-end/src/common/common.controller.ts
+++ b/back-end/src/common/common.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { CommonService } from './common.service';
+
+@Controller('common')
+export class CommonController {
+  constructor(private readonly commonService: CommonService) {}
+}

--- a/back-end/src/common/common.module.ts
+++ b/back-end/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommonService } from './common.service';
+import { CommonController } from './common.controller';
+
+@Module({
+  controllers: [CommonController],
+  providers: [CommonService],
+})
+export class CommonModule {}

--- a/back-end/src/common/common.service.spec.ts
+++ b/back-end/src/common/common.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonService } from './common.service';
+
+describe('CommonService', () => {
+  let service: CommonService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommonService],
+    }).compile();
+
+    service = module.get<CommonService>(CommonService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/back-end/src/common/common.service.ts
+++ b/back-end/src/common/common.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommonService {}

--- a/back-end/src/common/entity/base.entity.ts
+++ b/back-end/src/common/entity/base.entity.ts
@@ -1,0 +1,16 @@
+import {
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export abstract class BaseModel {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updateAt: Date;
+}

--- a/back-end/src/posts/entities/post.entity.ts
+++ b/back-end/src/posts/entities/post.entity.ts
@@ -1,6 +1,7 @@
 import { User } from "src/user/user.entity";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { Category } from "./category.entity";
+import { Comment } from "./comment.entity";
 
 
 
@@ -30,4 +31,7 @@ export class Post {
 
   @Column({ type: 'int', default: 0 })
   viewCount: number;
+
+  @OneToMany(()=>Comment, (comment)=>comment.post)
+  comments:Comment[]
 }

--- a/back-end/src/posts/posts.service.ts
+++ b/back-end/src/posts/posts.service.ts
@@ -362,7 +362,6 @@ export class PostsService {
       .leftJoinAndSelect('post.user', 'user')
       .leftJoinAndSelect('post.category', 'category');
   
-    // 🔍 조건 분기
     if (type === 'title') {
       query.where('post.title LIKE :keyword', { keyword: `%${keyword}%` });
     } else if (type === 'content') {

--- a/back-end/src/resume/entities/introduction.entity.ts
+++ b/back-end/src/resume/entities/introduction.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { ResumeModel } from "./resume.entity";
+
+@Entity()
+export class IntroductionModel{
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    headline: string;
+
+    @Column()
+    description: string;
+
+
+    @OneToOne(() => ResumeModel, (resume) => resume.introduction)
+    @JoinColumn()
+    resume: ResumeModel;
+}

--- a/back-end/src/resume/entities/project-outcome.entity.ts
+++ b/back-end/src/resume/entities/project-outcome.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { ProjectModel } from './project.entity';
+
+@Entity()
+export class ProjectOutcomeModel {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  task: string;
+
+  @Column()
+  result: string;
+
+  @ManyToOne(() => ProjectModel, (resume) => resume.outcomes)
+  project: ProjectModel;
+}

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ResumeModel } from './resume.entity';
+import { ProjectOutcomeModel } from './project-outcome.entity';
+
+@Entity()
+export class ProjectModel {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  description: string;
+
+  @ManyToOne(() => ResumeModel, (resume) => resume.projects)
+  resume: ResumeModel;
+
+  @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project)
+  outcomes: ProjectOutcomeModel[];
+}

--- a/back-end/src/resume/entities/resume.entity.ts
+++ b/back-end/src/resume/entities/resume.entity.ts
@@ -1,0 +1,25 @@
+import { BaseModel } from 'src/common/entity/base.entity';
+import { User } from 'src/user/user.entity';
+import { Entity, JoinTable, ManyToMany, ManyToOne, OneToMany, OneToOne } from 'typeorm';
+import { IntroductionModel } from './introduction.entity';
+import { SkillModel } from './skill.entity';
+import { ProjectModel } from './project.entity';
+
+@Entity()
+export class ResumeModel extends BaseModel {
+  @ManyToOne(() => User, (user) => user.resumes,{onDelete: 'CASCADE'})
+  author: User;
+
+  @OneToOne(() => IntroductionModel, (introduction) => introduction.resume)
+  introduction: IntroductionModel;
+
+
+  @ManyToMany(() => SkillModel, (skills) => skills.resumes)
+  @JoinTable()
+  skills: SkillModel[];
+
+
+
+  @OneToMany(() => ProjectModel, (project) => project.resume)
+  projects: ProjectModel[];
+}

--- a/back-end/src/resume/entities/skill.entity.ts
+++ b/back-end/src/resume/entities/skill.entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from "typeorm";
+import { ResumeModel } from "./resume.entity";
+
+@Entity()
+export class SkillModel {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToMany(()=> ResumeModel, (resume) => resume.skills)
+    resumes:ResumeModel;
+    
+}

--- a/back-end/src/resume/resumeGeneration.Service.ts
+++ b/back-end/src/resume/resumeGeneration.Service.ts
@@ -13,18 +13,18 @@ export class ResumeGenerationService {
 
   async generateResume(profileData: string): Promise<string> {
 
-    // 간결하고 직관적인 영어 프롬프트로 작성
     const prompt = `
 Using the following GitHub profile data, generate a structured JSON object for a developer portfolio. 
 
 ### JSON Structure:
 {
   "introduction": {
+    "headline": "",// A short headline-style sentence to introduce yourself at the top of the resume. Summarize your identity as a developer in one impactful phrase (e.g., "끈기 있게 성장하는 백엔드 개발자입니다", "사용자 경험을 생각하는 프론트엔드 개발자입니다").
     "description": "" // Developer's self-introduction in Korean (400-500 characters), focusing on their experience, core skills, and career goals.
   },
   "skills": {
     "strengths": [], // List of key technical skills (e.g., React, Node.js, SQL).
-    "knowledgeable": [] // List of secondary or familiar skills (e.g., Docker, TailwindCSS).
+    "familiar": [] // List of secondary or familiar skills (e.g., Docker, TailwindCSS).
   },
   "projects": [
     {
@@ -32,7 +32,7 @@ Using the following GitHub profile data, generate a structured JSON object for a
       "description": "", // Brief description of the project in Korean.
       "outcomes": [
         {
-          "title": "", // A short title in Korean summarizing the task or achievement (e.g., "구글 인증 구현").
+          "task": "", // A short title in Korean summarizing the task or achievement (e.g., "구글 인증 구현").
           "result": "" // Detailed explanation in Korean. Describe:
           // - The specific action or task performed based on the commit message (e.g., "구글 인증 기능을 구현했습니다").
           // - The tools/technologies used, if applicable (e.g., "TypeScript와 Google API를 활용").

--- a/back-end/src/user/user.dto.ts
+++ b/back-end/src/user/user.dto.ts
@@ -7,8 +7,7 @@ import {
   IsString,
   Matches,
 } from 'class-validator';
-import { Transform } from 'class-transformer';  
-
+import { Transform } from 'class-transformer';
 
 export class CreateUserDto {
   @IsEmail()
@@ -28,11 +27,11 @@ export class UpdateUserDto {
   @IsString()
   name: string;
 
-  @Transform(({ value }) => new Date(value)) 
+  @Transform(({ value }) => new Date(value))
   @IsDate()
   birthDate?: Date;
 
- @IsNumber()
+  @IsNumber()
   phone_number?: number;
 
   @IsString()
@@ -58,6 +57,4 @@ export class UpdateUserDto {
   @IsString()
   @IsOptional()
   profile_image?: string;
-  
 }
-

--- a/back-end/src/user/user.entity.ts
+++ b/back-end/src/user/user.entity.ts
@@ -1,4 +1,5 @@
 import { Post } from 'src/posts/entities/post.entity';
+import { ResumeModel } from 'src/resume/entities/resume.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
@@ -43,4 +44,8 @@ export class User {
    
   @OneToMany(() => Post, (post) => post.user)
   posts: Post[];
+
+
+  @OneToMany(()=> ResumeModel, (resume)=> resume.author)
+  resumes: ResumeModel[];
 }


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- User 엔티티에 이력서 연관 관계 추가 (1:N)
- Resume 엔티티 생성 및 User, Introduction, Skills, Project 연관 설정
- Introduction 엔티티 생성 (1:1)
- Skills 엔티티 및 다대다 연관 설정
- Project, ProjectOutcome 엔티티 생성 및 연관 설정

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 차후 class validator및, resume API 작성 예정
