### PR TITLE
feat:GitHub 정보 조회 API 리팩토링 및 자기소개 DTO 유효성 검증 추가

### DIFF
--- a/back-end/.vscode/launch.json
+++ b/back-end/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // IntelliSense를 사용하여 가능한 특성에 대해 알아보세요.
+  // 기존 특성에 대한 설명을 보려면 가리킵니다.
+  // 자세한 내용을 보려면 https://go.microsoft.com/fwlink/?linkid=830387을(를) 방문하세요.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug NestJS",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:debug"],
+      "console": "integratedTerminal",
+      "restart": true,
+      "port": 9229,
+      "autoAttachChildProcesses": true
+    }
+  ]
+}

--- a/back-end/src/resume/dto/save-introduction.dto.ts
+++ b/back-end/src/resume/dto/save-introduction.dto.ts
@@ -1,0 +1,5 @@
+import { PickType } from "@nestjs/mapped-types";
+import { IntroductionModel } from "../entities/introduction.entity";
+
+export class SaveIntroductionDto extends PickType(IntroductionModel,["headline", "description"]) {
+}

--- a/back-end/src/resume/entities/introduction.entity.ts
+++ b/back-end/src/resume/entities/introduction.entity.ts
@@ -1,19 +1,27 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
-import { ResumeModel } from "./resume.entity";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ResumeModel } from './resume.entity';
+import { IsString } from 'class-validator';
 
 @Entity()
-export class IntroductionModel{
-    @PrimaryGeneratedColumn()
-    id: number;
+export class IntroductionModel {
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @Column()
-    headline: string;
+  @Column()
+  @IsString()
+  headline: string;
 
-    @Column()
-    description: string;
+  @Column()
+  @IsString()
+  description: string;
 
-
-    @OneToOne(() => ResumeModel, (resume) => resume.introduction)
-    @JoinColumn()
-    resume: ResumeModel;
+  @OneToOne(() => ResumeModel, (resume) => resume.introduction)
+  @JoinColumn()
+  resume: ResumeModel;
 }

--- a/back-end/src/resume/resume.service.ts
+++ b/back-end/src/resume/resume.service.ts
@@ -1,20 +1,74 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
+import { UserService } from 'src/user/user.service';
 
 @Injectable()
 export class ResumeService {
   // GitHub API를 통해 레포지토리 리스트 가져오기
+
+  constructor(private readonly userService: UserService) {}
+
+  async getGitHubData(name: string, email: string) {
+    const userinfo = [];
+
+    const user = await this.userService.getUser(email);
+
+    const username = user.githubUrl.split('/').pop();
+
+    // 모든 레포지토리 가져오기
+    const repositories = await this.getUserRepositories(username);
+
+    // 레포지토리를 크기순으로 내림차순 정렬 후 최대 7개 선택
+    const topRepositories = repositories
+      .sort((a, b) => b.size - a.size)
+      .slice(0, 7);
+
+    // 상위 7개의 레포지토리에 대해 정보 수집
+    for (const repository of topRepositories) {
+      const repoInfo = {
+        name: repository.name,
+        description: repository.description,
+        language: repository.language,
+        size: repository.size,
+        stargazers_count: repository.stargazers_count,
+        forks_count: repository.forks_count,
+        html_url: repository.html_url,
+        readme_content:
+          !repository.description &&
+          (await this.getReadmeContent(username, repository.name)),
+      };
+
+      const additionalData = await this.getAdditionalRepositoryData(
+        username,
+        repository.name,
+      );
+      userinfo.push({ ...repoInfo, ...additionalData });
+    }
+
+    if (userinfo.length === 0) {
+      throw new Error('No repositories found for the user');
+    }
+    
+    return userinfo;
+  }
+
   async getUserRepositories(username: string) {
     try {
-      const response = await axios.get(`https://api.github.com/users/${username}/repos`, {
-        headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-          Accept: 'application/vnd.github.v3+json',
+      const response = await axios.get(
+        `https://api.github.com/users/${username}/repos`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            Accept: 'application/vnd.github.v3+json',
+          },
         },
-      });
+      );
       return response.data; // 레포지토리 리스트 반환
     } catch (error) {
-      console.error('Error fetching GitHub repositories:', error.response?.data || error.message);
+      console.error(
+        'Error fetching GitHub repositories:',
+        error.response?.data || error.message,
+      );
       throw new Error('Failed to fetch GitHub repositories');
     }
   }
@@ -22,115 +76,133 @@ export class ResumeService {
   // README 파일을 가져오는 함수
   async getReadmeContent(username: string, repoName: string) {
     try {
-      const response = await axios.get(`https://api.github.com/repos/${username}/${repoName}/contents/README.md`, {
-        headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-          Accept: 'application/vnd.github.v3+json',
+      const response = await axios.get(
+        `https://api.github.com/repos/${username}/${repoName}/contents/README.md`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            Accept: 'application/vnd.github.v3+json',
+          },
         },
-      });
-  
+      );
+
       // base64로 인코딩된 README 파일을 디코딩
-      const content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-  
+      const content = Buffer.from(response.data.content, 'base64').toString(
+        'utf-8',
+      );
+
       // 모든 HTML 태그를 \n으로 치환
       let cleanedText = content.replace(/<\/?[^>]+(>|$)/g, '\n');
-  
+
       // 이미지 태그 제거
       cleanedText = cleanedText.replace(/!\[.*?\]\(.*?\)/g, '');
-  
+
       // '\n' + 같은 패턴 제거
       cleanedText = cleanedText.replace(/\\n\s*\+/g, '');
-  
+
       // 여러 개의 연속된 공백을 한 개로
       cleanedText = cleanedText.replace(/\s+/g, ' ');
-  
+
       // 중복된 줄바꿈을 하나로 통합
       cleanedText = cleanedText.replace(/\n+/g, '\n');
-  
+
       return cleanedText.trim(); // 최종적으로 텍스트 반환
     } catch (error) {
       if (error.response && error.response.status === 404) {
         return 'README not available';
       } else {
-        console.error(`Error fetching README for ${repoName}:`, error.response?.data || error.message);
+        console.error(
+          `Error fetching README for ${repoName}:`,
+          error.response?.data || error.message,
+        );
         return 'Error fetching README';
       }
     }
   }
-  
-  
 
+  // 커밋 메시지, 기여자 정보, 풀 리퀘스트, 릴리즈 정보 등 추가 로직들
+  async getAdditionalRepositoryData(username: string, repositoryName: string) {
+    const pp: any = {};
 
-// 커밋 메시지, 기여자 정보, 풀 리퀘스트, 릴리즈 정보 등 추가 로직들
-async getAdditionalRepositoryData(username: string, repositoryName: string) {
-  const pp: any = {};
+    try {
+      // 커밋 메시지 가져오기
+      const commitMessages = await axios.get(
+        `https://api.github.com/repos/${username}/${repositoryName}/commits`,
+        {
+          headers: this.getAuthHeaders(),
+        },
+      );
 
-  try {
-    // 커밋 메시지 가져오기
-    const commitMessages = await axios.get(
-      `https://api.github.com/repos/${username}/${repositoryName}/commits`, {
-        headers: this.getAuthHeaders(),
-      });
+      // username에 해당하는 사용자의 커밋만 필터링
+      pp.recent_commit_messages = commitMessages.data
+        .filter((commit) => commit.author && commit.author.login === username) // username 필터링
+        .map((commit) => {
+          let message = commit.commit.message;
+          message = message.replace(/\n\s*\+/g, ''); // '\n' + 패턴 제거
+          message = message.replace(/\s+/g, ' '); // 여러 공백을 한 개로
+          message = message.replace(/\n+/g, '\n'); // 여러 줄바꿈을 한 줄로 통합
+          return message.trim();
+        })
+        .filter((message, index, self) => {
+          // 불필요한 메시지를 제거
+          const ignorePattern =
+            /^(merge( branch)?|update|initial commit|release|resolve|bump|create readme|fix conflicts)/i;
+          if (ignorePattern.test(message)) return false;
 
-    // username에 해당하는 사용자의 커밋만 필터링
-    pp.recent_commit_messages = commitMessages.data
-      .filter(commit => commit.author && commit.author.login === username) // username 필터링
-      .map(commit => {
-        let message = commit.commit.message;
-        message = message.replace(/\n\s*\+/g, ''); // '\n' + 패턴 제거
-        message = message.replace(/\s+/g, ' '); // 여러 공백을 한 개로
-        message = message.replace(/\n+/g, '\n'); // 여러 줄바꿈을 한 줄로 통합
-        return message.trim();
-      })
-      .filter((message, index, self) => {
-        // 불필요한 메시지를 제거
-        const ignorePattern = /^(merge( branch)?|update|initial commit|release|resolve|bump|create readme|fix conflicts)/i;
-        if (ignorePattern.test(message)) return false;
+          // 중복 메시지 제거
+          return self.indexOf(message) === index;
+        })
+        .filter((message) => {
+          // 의미 없는 커밋 메시지 제거 (너무 짧은 메시지)
+          return message.length > 10; // 메시지가 10자 이하인 경우 제거
+        });
 
-        // 중복 메시지 제거
-        return self.indexOf(message) === index;
-      })
-      .filter(message => {
-        // 의미 없는 커밋 메시지 제거 (너무 짧은 메시지)
-        return message.length > 10; // 메시지가 10자 이하인 경우 제거
-      });
+      // 기여자 정보
+      const contributorsData = await axios.get(
+        `https://api.github.com/repos/${username}/${repositoryName}/contributors`,
+        {
+          headers: this.getAuthHeaders(),
+        },
+      );
+      const userContributions = contributorsData.data.find(
+        (contributor) => contributor.login === username,
+      );
+      pp.contributions = userContributions
+        ? userContributions.contributions
+        : 0;
 
-    // 기여자 정보
-    const contributorsData = await axios.get(
-      `https://api.github.com/repos/${username}/${repositoryName}/contributors`, {
-        headers: this.getAuthHeaders(),
-      });
-    const userContributions = contributorsData.data.find(contributor => contributor.login === username);
-    pp.contributions = userContributions ? userContributions.contributions : 0;
+      // 풀 리퀘스트
+      const pullRequests = await axios.get(
+        `https://api.github.com/repos/${username}/${repositoryName}/pulls`,
+        {
+          headers: this.getAuthHeaders(),
+        },
+      );
+      pp.recent_pull_requests = pullRequests.data.slice(0, 3).map((pr) => ({
+        title: pr.title,
+        created_at: pr.created_at,
+        status: pr.state,
+      }));
 
-    // 풀 리퀘스트
-    const pullRequests = await axios.get(
-      `https://api.github.com/repos/${username}/${repositoryName}/pulls`, {
-        headers: this.getAuthHeaders(),
-      });
-    pp.recent_pull_requests = pullRequests.data.slice(0, 3).map(pr => ({
-      title: pr.title,
-      created_at: pr.created_at,
-      status: pr.state,
-    }));
+      // 릴리즈 정보
+      const releasesData = await axios.get(
+        `https://api.github.com/repos/${username}/${repositoryName}/releases`,
+        {
+          headers: this.getAuthHeaders(),
+        },
+      );
+      pp.latest_release =
+        releasesData.data.length > 0 ? releasesData.data[0].name : 'No release';
+    } catch (error) {
+      console.error(
+        'Error fetching repository data:',
+        error.response?.data || error.message,
+      );
+      throw new Error('Failed to fetch repository data');
+    }
 
-    // 릴리즈 정보
-    const releasesData = await axios.get(
-      `https://api.github.com/repos/${username}/${repositoryName}/releases`, {
-        headers: this.getAuthHeaders(),
-      });
-    pp.latest_release = releasesData.data.length > 0 ? releasesData.data[0].name : 'No release';
-
-  } catch (error) {
-    console.error('Error fetching repository data:', error.response?.data || error.message);
-    throw new Error('Failed to fetch repository data');
+    return pp;
   }
-
-  return pp;
-}
-
-
-  
 
   // 인증 헤더 생성 함수
   private getAuthHeaders() {

--- a/back-end/src/resume/resumeGeneration.Service.ts
+++ b/back-end/src/resume/resumeGeneration.Service.ts
@@ -12,7 +12,6 @@ export class ResumeGenerationService {
   }
 
   async generateResume(profileData: string): Promise<string> {
-
     const prompt = `
 Using the following GitHub profile data, generate a structured JSON object for a developer portfolio. 
 
@@ -65,12 +64,6 @@ Using the following GitHub profile data, generate a structured JSON object for a
 GitHub Profile Data:
 ${profileData}
 `;
-
-
-
-
-
-
 
     try {
       const response = await this.openai.chat.completions.create({

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -23,8 +23,6 @@
         "dayjs": "^1.11.13",
         "dompurify": "^3.2.4",
         "framer-motion": "^11.12.0",
-        "pixi-viewport": "^6.0.3",
-        "pixi.js": "^7.4.3",
         "quill": "^2.0.3",
         "quill-image-resize-module": "^3.0.0",
         "quill-image-resize-module-ts": "^3.0.3",
@@ -1819,22 +1817,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pixi/accessibility": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
-      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/events": "7.4.3"
-      }
-    },
     "node_modules/@pixi/app": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
       "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1845,6 +1833,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
       "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.12"
       },
@@ -1857,6 +1846,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
       "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -1865,29 +1855,22 @@
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
-      "license": "MIT"
-    },
-    "node_modules/@pixi/compressed-textures": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
-      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
       "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.3",
-        "@pixi/core": "7.4.3"
-      }
+      "peer": true
     },
     "node_modules/@pixi/constants": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
       "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/core": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
       "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -1908,94 +1891,24 @@
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
       "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/events": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
-      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
       }
     },
     "node_modules/@pixi/extensions": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
       "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
-      "license": "MIT"
-    },
-    "node_modules/@pixi/extract": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
-      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
       "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-alpha": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
-      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-blur": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
-      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-color-matrix": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
-      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-displacement": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
-      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-fxaa": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
-      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/filter-noise": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
-      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3"
-      }
+      "peer": true
     },
     "node_modules/@pixi/graphics": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
       "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2006,13 +1919,15 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
       "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/mesh": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
       "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -2023,39 +1938,10 @@
       "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
       "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/mesh": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
-      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
-      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/display": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
-      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3"
       }
     },
     "node_modules/@pixi/particle-container": {
@@ -2063,22 +1949,11 @@
       "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
       "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
         "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/prepare": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
-      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/graphics": "7.4.3",
-        "@pixi/text": "7.4.3"
       }
     },
     "node_modules/@pixi/react": {
@@ -2119,13 +1994,15 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
       "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/settings": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
       "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "7.4.3",
         "@types/css-font-loading-module": "^0.0.12",
@@ -2137,6 +2014,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
       "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -2147,6 +2025,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
       "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/sprite": "7.4.3"
@@ -2157,20 +2036,11 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
       "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
         "@pixi/sprite": "7.4.3"
-      }
-    },
-    "node_modules/@pixi/spritesheet": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
-      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.3",
-        "@pixi/core": "7.4.3"
       }
     },
     "node_modules/@pixi/text": {
@@ -2178,6 +2048,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
       "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/sprite": "7.4.3"
@@ -2188,6 +2059,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
       "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.4.3",
         "@pixi/core": "7.4.3",
@@ -2196,23 +2068,12 @@
         "@pixi/text": "7.4.3"
       }
     },
-    "node_modules/@pixi/text-html": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
-      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/sprite": "7.4.3",
-        "@pixi/text": "7.4.3"
-      }
-    },
     "node_modules/@pixi/ticker": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
       "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/extensions": "7.4.3",
         "@pixi/settings": "7.4.3",
@@ -2224,6 +2085,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
       "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -3002,7 +2864,8 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
@@ -3014,7 +2877,8 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -3988,7 +3852,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.145",
@@ -4285,7 +4150,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -4926,7 +4792,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/its-fine": {
       "version": "1.2.5",
@@ -5329,6 +5196,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5518,57 +5386,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pixi-viewport": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
-      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "pixi.js": ">=8"
-      }
-    },
-    "node_modules/pixi.js": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
-      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/accessibility": "7.4.3",
-        "@pixi/app": "7.4.3",
-        "@pixi/assets": "7.4.3",
-        "@pixi/compressed-textures": "7.4.3",
-        "@pixi/core": "7.4.3",
-        "@pixi/display": "7.4.3",
-        "@pixi/events": "7.4.3",
-        "@pixi/extensions": "7.4.3",
-        "@pixi/extract": "7.4.3",
-        "@pixi/filter-alpha": "7.4.3",
-        "@pixi/filter-blur": "7.4.3",
-        "@pixi/filter-color-matrix": "7.4.3",
-        "@pixi/filter-displacement": "7.4.3",
-        "@pixi/filter-fxaa": "7.4.3",
-        "@pixi/filter-noise": "7.4.3",
-        "@pixi/graphics": "7.4.3",
-        "@pixi/mesh": "7.4.3",
-        "@pixi/mesh-extras": "7.4.3",
-        "@pixi/mixin-cache-as-bitmap": "7.4.3",
-        "@pixi/mixin-get-child-by-name": "7.4.3",
-        "@pixi/mixin-get-global-position": "7.4.3",
-        "@pixi/particle-container": "7.4.3",
-        "@pixi/prepare": "7.4.3",
-        "@pixi/sprite": "7.4.3",
-        "@pixi/sprite-animated": "7.4.3",
-        "@pixi/sprite-tiling": "7.4.3",
-        "@pixi/spritesheet": "7.4.3",
-        "@pixi/text": "7.4.3",
-        "@pixi/text-bitmap": "7.4.3",
-        "@pixi/text-html": "7.4.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -5662,6 +5479,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -6389,6 +6207,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -6408,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -6424,6 +6244,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6442,6 +6263,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6850,6 +6672,7 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -6862,7 +6685,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/use-sync-external-store": {
       "version": "1.5.0",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -25,8 +25,6 @@
     "dayjs": "^1.11.13",
     "dompurify": "^3.2.4",
     "framer-motion": "^11.12.0",
-    "pixi-viewport": "^6.0.3",
-    "pixi.js": "^7.4.3",
     "quill": "^2.0.3",
     "quill-image-resize-module": "^3.0.0",
     "quill-image-resize-module-ts": "^3.0.3",


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- 깃허브 정보 불러오기 API의 엔드포인트를 /resume/github/repos로 경로 정리/변경
- GitHub 레포지토리 조회 로직을 ResumeService.getGitHubData로 분리
- 응답 데이터 정제 및 정렬 로직 유지하면서 서비스 책임 분리
- IntroductionModel에 @IsString 데코레이터 적용
- SaveIntroductionDto 클래스 생성 및 PickType으로 필요한 필드만 선택


## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
