### PR TITLE
feat: UUID 기반 PK로 변경 및 Profile/Project/Skill 관계 구조 개선

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -23,6 +23,8 @@ import { ResumeModel } from './resume/entities/resume.entity';
 import { ProjectOutcomeModel } from './resume/entities/project-outcome.entity';
 import { ContactModel } from './contact/entity/contact.entity';
 import { APP_INTERCEPTOR } from '@nestjs/core';
+import { ENV_DB_DATABASE_KEY, ENV_DB_HOST_KEY, ENV_DB_PASSWORD_KEY, ENV_DB_PORT_KEY, ENV_DB_SYNC_KEY, ENV_DB_USERNAME_KEY } from './common/const/env-keys.const';
+import { ProfileModel } from './resume/entities/profile.entity';
 
 
 
@@ -31,14 +33,14 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot({
       type: 'mysql',
-      host: process.env.DB_HOST, 
-      port: parseInt(process.env.DB_PORT, 10) || 3306,
-      username: process.env.DB_USERNAME, 
-      password: process.env.DB_PASSWORD, 
-      database: process.env.DB_DATABASE, 
-      entities: [User, Post, Category, Like, Comment, BaseModel,IntroductionModel, ProjectModel, SkillModel, ResumeModel, ProjectOutcomeModel, ContactModel],
+      host: process.env[ENV_DB_HOST_KEY], 
+      port: parseInt(process.env[ENV_DB_PORT_KEY], 10) || 3306,
+      username: process.env[ENV_DB_USERNAME_KEY], 
+      password: process.env[ENV_DB_PASSWORD_KEY], 
+      database: process.env[ENV_DB_DATABASE_KEY], 
+      entities: [User, Post, Category, Like, Comment, BaseModel,IntroductionModel, ProjectModel, SkillModel, ResumeModel, ProjectOutcomeModel, ContactModel, ProfileModel],
       autoLoadEntities: true,
-      synchronize: process.env.DB_SYNC === 'true', 
+      synchronize: process.env[ENV_DB_SYNC_KEY] === 'true', 
     }),
     UserModule,
     AuthModule,

--- a/back-end/src/resume/entities/introduction.entity.ts
+++ b/back-end/src/resume/entities/introduction.entity.ts
@@ -10,8 +10,9 @@ import { IsString } from 'class-validator';
 
 @Entity()
 export class IntroductionModel {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
 
   @Column()
   @IsString()

--- a/back-end/src/resume/entities/profile.entity.ts
+++ b/back-end/src/resume/entities/profile.entity.ts
@@ -1,0 +1,46 @@
+import { IsEmail, IsString, IsUrl } from 'class-validator';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ResumeModel } from './resume.entity';
+
+@Entity()
+export class ProfileModel {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @IsString()
+  @Column()
+  username: string;
+
+  @IsEmail()
+  @Column()
+  email: string;
+
+  @Column()
+  phoneNumber: number;
+
+  @IsString()
+  @Column()
+  address: string;
+
+  @IsString()
+  @Column({ nullable: true })
+  education: string;
+
+  @IsUrl()
+  @Column({ nullable: true })
+  githubUrl: string;
+
+  @IsUrl()
+  @Column({ nullable: true })
+  blogUrl: string;
+
+  @OneToOne(() => ResumeModel, (resume) => resume.profile)
+  @JoinColumn()
+  resume: ResumeModel;
+}

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -1,17 +1,20 @@
 import {
   Column,
   Entity,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ResumeModel } from './resume.entity';
 import { ProjectOutcomeModel } from './project-outcome.entity';
+import { SkillModel } from './skill.entity';
 
 @Entity()
 export class ProjectModel {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   name: string;
@@ -19,9 +22,23 @@ export class ProjectModel {
   @Column()
   description: string;
 
+  @Column()
+  startDate: Date;
+
+  @Column()
+  endDate: Date;
+
   @ManyToOne(() => ResumeModel, (resume) => resume.projects)
   resume: ResumeModel;
 
   @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project)
   outcomes: ProjectOutcomeModel[];
+
+  @ManyToMany(() => SkillModel, { cascade: true })
+  @JoinTable({
+    name: 'project_skills',
+    joinColumn: { name: 'project_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'skill_id', referencedColumnName: 'id' },
+  })
+  skills: SkillModel[];
 }

--- a/back-end/src/resume/entities/resume.entity.ts
+++ b/back-end/src/resume/entities/resume.entity.ts
@@ -1,6 +1,7 @@
 import { BaseModel } from 'src/common/entity/base.entity';
 import { User } from 'src/user/user.entity';
 import {
+  Column,
   Entity,
   JoinTable,
   ManyToMany,
@@ -12,10 +13,12 @@ import { IntroductionModel } from './introduction.entity';
 import { SkillModel } from './skill.entity';
 import { ProjectModel } from './project.entity';
 import { IsString } from 'class-validator';
+import { ProfileModel } from './profile.entity';
 
 @Entity()
 export class ResumeModel extends BaseModel {
   @IsString()
+  @Column()
   title: string;
 
   @ManyToOne(() => User, (user) => user.resumes, { onDelete: 'CASCADE' })
@@ -23,6 +26,9 @@ export class ResumeModel extends BaseModel {
 
   @OneToOne(() => IntroductionModel, (introduction) => introduction.resume)
   introduction: IntroductionModel;
+
+  @OneToOne(() => ProfileModel, (profile) => profile.resume)
+  profile: ProfileModel;
 
   @ManyToMany(() => SkillModel, (skill) => skill.strongResumes)
   @JoinTable({

--- a/back-end/src/resume/entities/skill.entity.ts
+++ b/back-end/src/resume/entities/skill.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { ResumeModel } from './resume.entity';
+import { ProjectModel } from './project.entity';
 
 @Entity()
 export class SkillModel {
@@ -14,4 +15,7 @@ export class SkillModel {
 
   @ManyToMany(() => ResumeModel, (resume) => resume.fam_skills)
   familiarResumes: ResumeModel[];
+
+  @ManyToMany(() => ProjectModel, (project) => project.skills)
+  projects: ProjectModel[];
 }

--- a/back-end/src/resume/resume.module.ts
+++ b/back-end/src/resume/resume.module.ts
@@ -10,9 +10,10 @@ import { IntroductionModel } from './entities/introduction.entity';
 import { ProjectModel } from './entities/project.entity';
 import { ProjectOutcomeModel } from './entities/project-outcome.entity';
 import { SkillModel } from './entities/skill.entity';
+import { ProfileModel } from './entities/profile.entity';
 
 @Module({
-  imports: [UserModule,TypeOrmModule.forFeature([ResumeModel, IntroductionModel, ProjectModel, ProjectOutcomeModel, SkillModel])], // 여기에 필요한 엔티티를 추가하세요
+  imports: [UserModule,TypeOrmModule.forFeature([ResumeModel, IntroductionModel, ProjectModel, ProjectOutcomeModel, SkillModel, ProfileModel])], // 여기에 필요한 엔티티를 추가하세요
   controllers: [ResumeController],
   providers: [SessionSerializer,ResumeService,ResumeGenerationService], 
 })


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- IntroductionModel, ProjectModel의 기본 키를 UUID로 변경
- ProfileModel 새로 생성하여 Resume와 1:1 연결
- ProjectModel에 startDate, endDate, skills(M:N) 추가
- SkillModel과 ProjectModel의 N:M 관계 설정
- ResumeModel에 ProfileModel 연관관계 추가
- 전체 엔티티 간 타입 및 관계 정비

## 체크리스트
- [o] 코드 리뷰를 완료했습니다.
- [o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
