### PR TITLE
chore:도커 볼륨 데이터(.db-data) gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+#db-data
+db-data/


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
도커 볼륨 데이터(.db-data) gitignore 추가
- git에 올라간 Docker MySQL 볼륨 제외
- 불필요한 DB 데이터 커밋 방지

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
