### PR TITLE
feat: Career, Achievement, Custom 섹션 추가

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -25,6 +25,9 @@ import { ContactModel } from './contact/entity/contact.entity';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import * as Joi from 'joi';
 import { ProfileModel } from './resume/entities/profile.entity';
+import { CareerModel } from './resume/entities/career.entity';
+import { AchievementModel } from './resume/entities/achievement.entity';
+import { CustomModel } from './resume/entities/custom.entity';
 
 @Module({
   imports: [
@@ -63,6 +66,9 @@ import { ProfileModel } from './resume/entities/profile.entity';
           ProjectOutcomeModel,
           ContactModel,
           ProfileModel,
+          CareerModel,
+          AchievementModel,
+          CustomModel,
         ],
         autoLoadEntities: true,
         synchronize: true,

--- a/back-end/src/resume/dto/create-achievement.dto.ts
+++ b/back-end/src/resume/dto/create-achievement.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, IsDateString, IsOptional, IsUUID } from 'class-validator';
+
+export class CreateAchievementDto {
+  @IsUUID()
+  id: string;
+
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  organization?: string;
+
+  @IsDateString()
+  date: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/back-end/src/resume/dto/create-achievements.dto.ts
+++ b/back-end/src/resume/dto/create-achievements.dto.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsEnum, ValidateNested } from 'class-validator';
+import { CreateAchievementDto } from './create-achievement.dto';
+import { Type } from 'class-transformer';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+
+export class CreateAchievementsDto {
+
+  @IsEnum(ResumeBlockType)
+  type: ResumeBlockType.ACHIEVEMENTS;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateAchievementDto)
+  items: CreateAchievementDto[];
+}

--- a/back-end/src/resume/dto/create-career.dto.ts
+++ b/back-end/src/resume/dto/create-career.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsDateString, IsOptional, IsUUID } from 'class-validator';
+
+export class CreateCareerDto {
+  @IsUUID()
+  id: string;
+
+  @IsString()
+  company: string;
+
+  @IsString()
+  position: string;
+
+  @IsDateString()
+  start_date: string;
+
+  @IsOptional()
+  @IsDateString()
+  end_date?: string;
+
+  @IsString()
+  description: string;
+}

--- a/back-end/src/resume/dto/create-careers.dto.ts
+++ b/back-end/src/resume/dto/create-careers.dto.ts
@@ -1,0 +1,14 @@
+import { IsArray, IsEnum, ValidateNested } from "class-validator";
+import { ResumeBlockType } from "../enum/resume-type.enum";
+import { Type } from "class-transformer";
+import { CreateCareerDto } from "./create-career.dto";
+
+export class CreateCareersDto {
+  @IsEnum(ResumeBlockType)
+  type: ResumeBlockType.CAREERS;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateCareerDto)
+  items: CreateCareerDto[];
+}

--- a/back-end/src/resume/dto/create-custom.dto.ts
+++ b/back-end/src/resume/dto/create-custom.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsUUID, IsEnum } from 'class-validator';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+
+export class CreateCustomDto {
+  @IsUUID()
+  id: string;
+
+  @IsEnum(ResumeBlockType)
+  type: ResumeBlockType.CUSTOM;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+}

--- a/back-end/src/resume/dto/create-project.dto.ts
+++ b/back-end/src/resume/dto/create-project.dto.ts
@@ -2,6 +2,7 @@ import {
   IsArray,
   IsDateString,
   IsNotEmpty,
+  IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
@@ -24,8 +25,9 @@ export class CreateProjectDto {
   @IsDateString()
   startDate: string;
 
+  @IsOptional()
   @IsDateString()
-  endDate: string;
+  endDate?: string;
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/back-end/src/resume/entities/achievement.entity.ts
+++ b/back-end/src/resume/entities/achievement.entity.ts
@@ -1,0 +1,28 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+  } from 'typeorm';
+  import { ResumeModel } from './resume.entity';
+  
+  @Entity()
+  export class AchievementModel {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+  
+    @Column()
+    title: string;
+  
+    @Column({ nullable: true })
+    organization: string;
+  
+    @Column()
+    date: Date;
+  
+    @Column({ nullable: true })
+    description: string;
+  
+    @ManyToOne(() => ResumeModel, (resume) => resume.achievements)
+    resume: ResumeModel;
+  }

--- a/back-end/src/resume/entities/career.entity.ts
+++ b/back-end/src/resume/entities/career.entity.ts
@@ -1,0 +1,31 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+  } from 'typeorm';
+  import { ResumeModel } from './resume.entity';
+  
+  @Entity()
+  export class CareerModel {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+  
+    @Column()
+    company: string;
+  
+    @Column()
+    position: string;
+  
+    @Column()
+    start_date: Date;
+  
+    @Column({ nullable: true })
+    end_date: Date;
+  
+    @Column()
+    description: string;
+  
+    @ManyToOne(() => ResumeModel, (resume) => resume.careers)
+    resume: ResumeModel;
+  }

--- a/back-end/src/resume/entities/custom.entity.ts
+++ b/back-end/src/resume/entities/custom.entity.ts
@@ -1,0 +1,22 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ResumeModel } from './resume.entity';
+
+@Entity()
+export class CustomModel {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column()
+  description: string;
+
+  @ManyToOne(() => ResumeModel, (resume) => resume.customs)
+  resume: ResumeModel;
+}

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -25,7 +25,7 @@ export class ProjectModel {
   @Column()
   startDate: Date;
 
-  @Column()
+  @Column({ nullable: true })
   endDate: Date;
 
   @ManyToOne(() => ResumeModel, (resume) => resume.projects)

--- a/back-end/src/resume/entities/resume.entity.ts
+++ b/back-end/src/resume/entities/resume.entity.ts
@@ -13,6 +13,9 @@ import { IntroductionModel } from './introduction.entity';
 import { SkillModel } from './skill.entity';
 import { ProjectModel } from './project.entity';
 import { ProfileModel } from './profile.entity';
+import { CareerModel } from './career.entity';
+import { AchievementModel } from './achievement.entity';
+import { CustomModel } from './custom.entity';
 
 @Entity()
 export class ResumeModel extends BaseModel {
@@ -46,4 +49,25 @@ export class ResumeModel extends BaseModel {
 
   @OneToMany(() => ProjectModel, (project) => project.resume, { cascade: true, onDelete: 'CASCADE' })
   projects: ProjectModel[];
+
+  @OneToMany(() => CareerModel, (career) => career.resume, { 
+    cascade: true, 
+    onDelete: 'CASCADE',
+    nullable: true 
+  })
+  careers: CareerModel[];
+
+  @OneToMany(() => AchievementModel, (achievement) => achievement.resume, { 
+    cascade: true, 
+    onDelete: 'CASCADE',
+    nullable: true 
+  })
+  achievements: AchievementModel[];
+
+  @OneToMany(() => CustomModel, (custom) => custom.resume, { 
+    cascade: true, 
+    onDelete: 'CASCADE',
+    nullable: true 
+  })
+  customs: CustomModel[];
 }

--- a/back-end/src/resume/entities/skill.entity.ts
+++ b/back-end/src/resume/entities/skill.entity.ts
@@ -21,4 +21,5 @@ export class SkillModel {
 
   @ManyToMany(() => ProjectModel, (project) => project.skills)
   projects: ProjectModel[];
+  
 }

--- a/back-end/src/resume/enum/resume-type.enum.ts
+++ b/back-end/src/resume/enum/resume-type.enum.ts
@@ -1,8 +1,8 @@
 export enum ResumeBlockType {
     PROFILE = 'profile',
     INTRODUCTION = 'introduction', 
-    CAREER = 'career',
-    ACHIEVEMENT = 'achievement',
+    CAREERS = 'careers',
+    ACHIEVEMENTS = 'achievements',
     SKILLS = 'skills',
     PROJECTS = 'projects',
     CUSTOM = 'custom',

--- a/back-end/src/resume/resume.controller.ts
+++ b/back-end/src/resume/resume.controller.ts
@@ -20,6 +20,9 @@ import { CreateIntroductionDto } from './dto/create-introduction.dto';
 import { CreateProfileDto } from './dto/create-profile.dto';
 import { CreateProjectsWidthOutcomesDto } from './dto/create-projects-width-outcomes.dto';
 import { CreateSkillsDto } from './dto/create-skills.dto';
+import { CreateAchievementsDto } from './dto/create-achievements.dto';
+import { CreateCustomDto } from './dto/create-custom.dto';
+import { CreateCareersDto } from './dto/create-careers.dto';
 
 @Controller('resumes')
 export class ResumeController {
@@ -146,5 +149,32 @@ export class ResumeController {
   @UseGuards(AuthenticatedGuard)
   async searchSkills(@Query('query') query: string) {
     return this.resumeService.searchSkills(query);
+  }
+
+  @Post(':id/achievements')
+  @UseGuards(AuthenticatedGuard)
+  async createAchievements(
+    @Param('id') id: string,
+    @Body() createAchievementsDto: CreateAchievementsDto,
+  ) {
+    return await this.resumeService.saveBlock(id, createAchievementsDto);
+  }
+
+  @Post(':id/custom')
+  @UseGuards(AuthenticatedGuard)
+  async createCustom(
+    @Param('id') id: string,
+    @Body() createCustomDto: CreateCustomDto,
+  ) {
+    return await this.resumeService.saveBlock(id, createCustomDto);
+  }
+
+  @Post(':id/careers')
+  @UseGuards(AuthenticatedGuard)
+  async createCareers(
+    @Param('id') id: string,
+    @Body() createCareersDto: CreateCareersDto,
+  ) {
+    return await this.resumeService.saveBlock(id, createCareersDto);
   }
 }

--- a/back-end/src/resume/resume.module.ts
+++ b/back-end/src/resume/resume.module.ts
@@ -12,6 +12,9 @@ import { ProjectOutcomeModel } from './entities/project-outcome.entity';
 import { SkillModel } from './entities/skill.entity';
 import { ProfileModel } from './entities/profile.entity';
 import { SkillSeederService } from './skill_seeder.service';
+import { AchievementModel } from './entities/achievement.entity';
+import { CareerModel } from './entities/career.entity';
+import { CustomModel } from './entities/custom.entity';
 
 @Module({
   imports: [
@@ -23,8 +26,11 @@ import { SkillSeederService } from './skill_seeder.service';
       ProjectOutcomeModel,
       SkillModel,
       ProfileModel,
+      CareerModel,
+      AchievementModel,
+      CustomModel,
     ]),
-  ], // 여기에 필요한 엔티티를 추가하세요
+  ],
   controllers: [ResumeController],
   providers: [
     SessionSerializer,


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
  - Career, Achievement, Custom 엔티티 생성
  - 각 섹션별 DTO 생성 (CreateCareerDto, CreateAchievementDto, CreateCustomDto)
  - ResumeService에 섹션별 서비스 로직 구현
  - ResumeModel에 새로운 섹션들과의 관계 설정
  - getResumeDetails에서 Custom 블록들을 개별 엔티티로 처리

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
