### PR TITLE
feat: 이력서 블록 순서 관리 시스템 및 블록 삭제 기능 구현

### DIFF
--- a/back-end/.vscode/launch.json
+++ b/back-end/.vscode/launch.json
@@ -1,35 +1,22 @@
 {
   "version": "0.2.0",
   "configurations": [
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Debug NestJS Backend",
-          "program": "${workspaceFolder}/back-end/src/main.ts",
-          "runtimeArgs": ["-r", "ts-node/register"],
-          "env": {
-              "NODE_ENV": "development"
-          },
-          "console": "integratedTerminal",
-          "skipFiles": [
-              "<node_internals>/**"
-          ],
-          "cwd": "${workspaceFolder}/back-end"
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug NestJS Backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:debug"],
+      "env": {
+        "NODE_ENV": "development",
+        "TS_NODE_CACHE": "false"
       },
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Debug Frontend",
-          "program": "${workspaceFolder}/front-end/src/main.tsx",
-          "runtimeArgs": ["-r", "ts-node/register"],
-          "env": {
-              "NODE_ENV": "development"
-          },
-          "console": "integratedTerminal",
-          "skipFiles": [
-              "<node_internals>/**"
-          ],
-          "cwd": "${workspaceFolder}/front-end"
-      }
+      "console": "integratedTerminal",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "cwd": "${workspaceFolder}/back-end",
+      "restart": true
+    }
   ]
 }

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -28,6 +28,7 @@ import { ProfileModel } from './resume/entities/profile.entity';
 import { CareerModel } from './resume/entities/career.entity';
 import { AchievementModel } from './resume/entities/achievement.entity';
 import { CustomModel } from './resume/entities/custom.entity';
+import { OrderModel } from './resume/entities/order.entity';
 
 @Module({
   imports: [
@@ -69,6 +70,7 @@ import { CustomModel } from './resume/entities/custom.entity';
           CareerModel,
           AchievementModel,
           CustomModel,
+          OrderModel,
         ],
         autoLoadEntities: true,
         synchronize: true,

--- a/back-end/src/resume/dto/update-block-orders.dto.ts
+++ b/back-end/src/resume/dto/update-block-orders.dto.ts
@@ -1,0 +1,22 @@
+import { IsArray, ValidateNested, IsNumber, IsEnum, IsUUID, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+
+export class BlockOrderItemDto {
+  @IsNumber()
+  order: number;
+
+  @IsEnum(ResumeBlockType)
+  blockType: ResumeBlockType;
+
+  @IsUUID()
+  @IsOptional()
+  blockId?: string; // 커스텀 블록의 경우에만 사용
+}
+
+export class UpdateBlockOrdersDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => BlockOrderItemDto)
+  blockOrders: BlockOrderItemDto[];
+}

--- a/back-end/src/resume/entities/order.entity.ts
+++ b/back-end/src/resume/entities/order.entity.ts
@@ -1,0 +1,25 @@
+import { BaseModel } from 'src/common/entity/base.entity';
+import { ResumeModel } from './resume.entity';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+import { Entity, Column, ManyToOne, JoinColumn } from 'typeorm';
+
+@Entity()
+export class OrderModel extends BaseModel {
+  @Column()
+  order: number;
+
+  @Column({
+    type: 'enum',
+    enum: ResumeBlockType
+  })
+  blockType: ResumeBlockType;
+
+  @Column({ nullable: true })
+  blockId: string; // 커스텀 블록의 경우에만 사용
+
+  @ManyToOne(() => ResumeModel, (resume) => resume.blockOrders, { 
+    onDelete: 'CASCADE' 
+  })
+  @JoinColumn({ name: 'resume_id' })
+  resume: ResumeModel;
+}

--- a/back-end/src/resume/entities/project-outcome.entity.ts
+++ b/back-end/src/resume/entities/project-outcome.entity.ts
@@ -12,6 +12,6 @@ export class ProjectOutcomeModel {
   @Column()
   result: string;
 
-  @ManyToOne(() => ProjectModel, (resume) => resume.outcomes)
+  @ManyToOne(() => ProjectModel, (resume) => resume.outcomes, { onDelete: 'CASCADE' })
   project: ProjectModel;
 }

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -31,7 +31,7 @@ export class ProjectModel {
   @ManyToOne(() => ResumeModel, (resume) => resume.projects)
   resume: ResumeModel;
 
-  @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project, { cascade: true, onDelete: 'CASCADE' })
+  @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project, { cascade: true })
   outcomes: ProjectOutcomeModel[];
 
   @ManyToMany(() => SkillModel, { cascade: true })

--- a/back-end/src/resume/entities/resume.entity.ts
+++ b/back-end/src/resume/entities/resume.entity.ts
@@ -16,6 +16,7 @@ import { ProfileModel } from './profile.entity';
 import { CareerModel } from './career.entity';
 import { AchievementModel } from './achievement.entity';
 import { CustomModel } from './custom.entity';
+import { OrderModel } from './order.entity';
 
 @Entity()
 export class ResumeModel extends BaseModel {
@@ -70,4 +71,10 @@ export class ResumeModel extends BaseModel {
     nullable: true 
   })
   customs: CustomModel[];
+
+  @OneToMany(() => OrderModel, (blockOrder) => blockOrder.resume, { 
+    cascade: true, 
+    onDelete: 'CASCADE' 
+  })
+  blockOrders: OrderModel[];
 }

--- a/back-end/src/resume/entities/skill.entity.ts
+++ b/back-end/src/resume/entities/skill.entity.ts
@@ -13,13 +13,13 @@ export class SkillModel {
   @Column({ nullable: true })
   icon: string;
 
-  @ManyToMany(() => ResumeModel, (resume) => resume.str_skills)
+  @ManyToMany(() => ResumeModel, (resume) => resume.str_skills, { onDelete: 'CASCADE' })
   strongResumes: ResumeModel[];
 
-  @ManyToMany(() => ResumeModel, (resume) => resume.fam_skills)
+  @ManyToMany(() => ResumeModel, (resume) => resume.fam_skills, { onDelete: 'CASCADE' })
   familiarResumes: ResumeModel[];
 
-  @ManyToMany(() => ProjectModel, (project) => project.skills)
+  @ManyToMany(() => ProjectModel, (project) => project.skills, { onDelete: 'CASCADE' })
   projects: ProjectModel[];
   
 }

--- a/back-end/src/resume/resume.controller.ts
+++ b/back-end/src/resume/resume.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Request,
   Body,
   HttpException,
@@ -23,6 +24,7 @@ import { CreateSkillsDto } from './dto/create-skills.dto';
 import { CreateAchievementsDto } from './dto/create-achievements.dto';
 import { CreateCustomDto } from './dto/create-custom.dto';
 import { CreateCareersDto } from './dto/create-careers.dto';
+import { UpdateBlockOrdersDto } from './dto/update-block-orders.dto';
 
 @Controller('resumes')
 export class ResumeController {
@@ -38,7 +40,7 @@ export class ResumeController {
   @UseGuards(AuthenticatedGuard)
   async generateResume(
     @Request() req,
-    @Body('profileData') profileData: string
+    @Body('profileData') profileData: string,
   ) {
     try {
       // 입력 데이터 길이를 최대 4000자로 제한
@@ -51,8 +53,7 @@ export class ResumeController {
         user.id,
       );
       return resume;
-
-    } catch(err) {
+    } catch (err) {
       console.error('Error generating resume:', err);
       throw new HttpException(
         'Failed to generate resume',
@@ -91,7 +92,7 @@ export class ResumeController {
 
     return resume;
   }
-  
+
   @Delete(':id')
   @UseGuards(AuthenticatedGuard)
   async deleteResume(@Param('id') id: string, @Request() req) {
@@ -103,19 +104,22 @@ export class ResumeController {
     return { message: 'Resume deleted successfully' };
   }
 
-  @Post(':id/introduction')
+  @Post(':id/introductions')
   @UseGuards(AuthenticatedGuard)
   async createIntroduction(
     @Param('id') id: string,
     @Body() createIntroductionDto: CreateIntroductionDto,
   ) {
-    return await this.resumeService.saveBlock(
-      id,
-      createIntroductionDto,
-    );
+    return await this.resumeService.saveBlock(id, createIntroductionDto);
   }
 
-  @Post(':id/profile')
+  @Delete(':id/introductions')
+  @UseGuards(AuthenticatedGuard)
+  async removeIntroduction(@Param('id') id: string) {
+    return this.resumeService.removeIntroduction(id);
+  }
+
+  @Post(':id/profiles')
   @UseGuards(AuthenticatedGuard)
   async createProfile(
     @Param('id') id: string,
@@ -124,16 +128,25 @@ export class ResumeController {
     return await this.resumeService.saveBlock(id, profileDto);
   }
 
+  @Delete(':id/profiles')
+  @UseGuards(AuthenticatedGuard)
+  async removeProfile(@Param('id') id: string) {
+    return this.resumeService.removeProfile(id);
+  }
+
   @Post(':id/projects')
   @UseGuards(AuthenticatedGuard)
   async createProject(
     @Param('id') id: string,
     @Body() createProjectsDto: CreateProjectsWidthOutcomesDto,
   ) {
-    return await this.resumeService.saveBlock(
-      id,
-      createProjectsDto,
-    );
+    return await this.resumeService.saveBlock(id, createProjectsDto);
+  }
+
+  @Delete(':id/projects')
+  @UseGuards(AuthenticatedGuard)
+  async removeProject(@Param('id') id: string) {
+    return this.resumeService.removeProject(id);
   }
 
   @Post(':id/skills')
@@ -143,6 +156,11 @@ export class ResumeController {
     @Body() createSkillsDto: CreateSkillsDto,
   ) {
     return await this.resumeService.saveBlock(id, createSkillsDto);
+  }
+
+  @Delete(':resumeId/skills')
+  async removeSkills(@Param('resumeId') resumeId: string) {
+    return this.resumeService.removeSkills(resumeId);
   }
 
   @Get('skills/search')
@@ -160,13 +178,10 @@ export class ResumeController {
     return await this.resumeService.saveBlock(id, createAchievementsDto);
   }
 
-  @Post(':id/custom')
+  @Delete(':id/achievements')
   @UseGuards(AuthenticatedGuard)
-  async createCustom(
-    @Param('id') id: string,
-    @Body() createCustomDto: CreateCustomDto,
-  ) {
-    return await this.resumeService.saveBlock(id, createCustomDto);
+  async removeAchievement(@Param('id') id: string) {
+    return this.resumeService.removeAchievement(id);
   }
 
   @Post(':id/careers')
@@ -176,5 +191,44 @@ export class ResumeController {
     @Body() createCareersDto: CreateCareersDto,
   ) {
     return await this.resumeService.saveBlock(id, createCareersDto);
+  }
+
+  @Delete(':id/careers')
+  @UseGuards(AuthenticatedGuard)
+  async removeCareer(@Param('id') id: string) {
+    return this.resumeService.removeCareer(id);
+  }
+
+  @Post(':id/customs')
+  @UseGuards(AuthenticatedGuard)
+  async createCustom(
+    @Param('id') id: string,
+    @Body() createCustomDto: CreateCustomDto,
+  ) {
+    return await this.resumeService.saveBlock(id, createCustomDto);
+  }
+
+  @Delete(':id/customs/:customId')
+  @UseGuards(AuthenticatedGuard)
+  async removeCustom(
+    @Param('id') id: string,
+    @Param('customId') customId: string,
+  ) {
+    return this.resumeService.removeCustom(id, customId);
+  }
+
+  @Put(':id/orders')
+  @UseGuards(AuthenticatedGuard)
+  async updateBlockOrders(
+    @Param('id') id: string,
+    @Body() updateBlockOrdersDto: UpdateBlockOrdersDto,
+  ) {
+    return this.resumeService.updateBlockOrders(id, updateBlockOrdersDto);
+  }
+
+  @Get(':id/orders')
+  @UseGuards(AuthenticatedGuard)
+  async getBlockOrders(@Param('id') id: string) {
+    return this.resumeService.getBlockOrders(id);
   }
 }

--- a/back-end/src/resume/resume.module.ts
+++ b/back-end/src/resume/resume.module.ts
@@ -15,6 +15,7 @@ import { SkillSeederService } from './skill_seeder.service';
 import { AchievementModel } from './entities/achievement.entity';
 import { CareerModel } from './entities/career.entity';
 import { CustomModel } from './entities/custom.entity';
+import { OrderModel } from './entities/order.entity';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { CustomModel } from './entities/custom.entity';
       CareerModel,
       AchievementModel,
       CustomModel,
+      OrderModel,
     ]),
   ],
   controllers: [ResumeController],


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
  - OrderModel 엔티티 추가 (블록 순서 관리)
  - 블록 순서 관리 메서드들 구현
    - addBlockToOrder: 블록 순서에 추가
    - removeBlockFromOrder: 블록 순서에서 제거
    - updateBlockOrders: 블록 순서 업데이트
    - getBlockOrders: 블록 순서 조회
  - 모든 블록 타입별 삭제 메서드 구현
    - removeProfile, removeIntroduction, removeSkills
    - removeProject, removeCareer, removeAchievement, removeCustom
  - 블록 생성/삭제 시 자동으로 순서 관리
  - 컨트롤러에 블록 삭제 엔드포인트 추가

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.
- [ o] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
- 
