### PR TITLE
feater: 이력서 부분저장시 redux createAsyncThunk로 api 연결

### DIFF
--- a/front-end/src/api/UpdateSection.tsx
+++ b/front-end/src/api/UpdateSection.tsx
@@ -1,0 +1,53 @@
+import { ResumeSection } from "../types/resume.type";
+
+export async function updateSectionAPI(section: ResumeSection) {
+    let sectionData;
+    if (["profile", "introduction"].includes(section.type)) {
+        const { id, ...withoutId } = section;
+        sectionData = withoutId
+    }
+    if (sectionData && sectionData.type === "profile") {
+        const githubUrl = "https://github.com/" + sectionData.githubUrl;
+        sectionData = { ...sectionData, githubUrl };
+
+    }
+    let url = `http://localhost:3000/resumes/${section.id}`;
+    switch (section.type) {
+        case "profile":
+            url += "/profiles";
+            break;
+        case "skills":
+            url += "/api/skills";
+            break;
+        case "projects":
+            url += "/api/projects";
+            break;
+        default:
+            throw new Error("Unknown section type");
+    }
+
+    try {
+        console.log(sectionData)
+        const response = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify(sectionData),
+        });
+
+        if (!response.ok) {
+            // 서버에서 에러 메시지 읽기
+            // console.log(errorData)
+        }
+
+        const updatedData = await response.json();
+        return { ...section, data: updatedData }; // 서버에서 받은 최신 데이터 포함
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            console.error("서버 에러 발생:", error);
+        } else {
+            console.error("알 수 없는 서버 에러:", error);
+        }
+        throw error; // 필요하면 상위에서 또 catch 가능
+    }
+}

--- a/front-end/src/components/resume/SectionOrderManager.tsx
+++ b/front-end/src/components/resume/SectionOrderManager.tsx
@@ -16,6 +16,8 @@ import {
 } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
 import type { ResumeData } from "../../types/resume.type";
+import { useDispatch } from "react-redux";
+import { updateOrder } from "../../redux/resumeSlice";
 
 interface Props {
   order: ResumeData["order"];
@@ -25,24 +27,27 @@ interface Props {
 export const SectionOrderManager = ({
   order,
   entities,
-}: // onClose,
-Props) => {
+}:
+  Props) => {
   const [localOrder, setLocalOrder] = useState(order);
   const initialOrderRef = useRef<string[]>([]);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     initialOrderRef.current = order;
   }, []);
-  //일단 , 리스트가 변경되면 setLocal 로
 
+  //일단 , 리스트가 변경되면 setLocal 로
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination) return;
     const newOrder = [...localOrder];
     const [removed] = newOrder.splice(result.source.index, 1);
     newOrder.splice(result.destination.index, 0, removed);
-    // onReorder(newOrder);
     setLocalOrder(newOrder);
   };
+
+
+
 
   return (
     <Fade in>
@@ -78,7 +83,7 @@ Props) => {
                 }}
               >
                 {localOrder.map((id, index) => {
-                  const entity = entities.find((i) => i.id === id);
+                  const entity = entities.find((i) => (i.type === id || i.id === id));
                   if (
                     !entity ||
                     entity.type === "project" ||
@@ -90,15 +95,15 @@ Props) => {
                     entity.type === "custom"
                       ? entity.title
                       : (
-                          {
-                            profile: "기본 정보",
-                            skills: "스킬",
-                            projects: "프로젝트",
-                            achievements: "수상/자격",
-                            careers: "경력",
-                            introduction: "자기소개",
-                          } as const
-                        )[entity.type];
+                        {
+                          profile: "기본 정보",
+                          skills: "스킬",
+                          projects: "프로젝트",
+                          achievements: "수상/자격",
+                          careers: "경력",
+                          introduction: "자기소개",
+                        } as const
+                      )[entity.type];
 
                   return (
                     <Draggable
@@ -153,7 +158,7 @@ Props) => {
           </Button>
           <Button
             variant="contained"
-            //  onClick={() => onReorder(localOrder)}
+            onClick={() => dispatch(updateOrder(localOrder))}
           >
             확인
           </Button>

--- a/front-end/src/components/resume/sections/ProfileSection.tsx
+++ b/front-end/src/components/resume/sections/ProfileSection.tsx
@@ -44,12 +44,12 @@ const ProfileFieldInput = ({
       slotProps={
         startAdornmentText
           ? {
-              input: {
-                startAdornment: (
-                  <InputAdornment position="start">github.com/</InputAdornment>
-                ),
-              },
-            }
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">github.com/</InputAdornment>
+              ),
+            },
+          }
           : undefined
       }
     />

--- a/front-end/src/hooks/useAppDispatch.ts
+++ b/front-end/src/hooks/useAppDispatch.ts
@@ -1,0 +1,4 @@
+import { useDispatch } from "react-redux";
+import type { AppDispatch } from "../redux/store";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();

--- a/front-end/src/hooks/useLocalSection.ts
+++ b/front-end/src/hooks/useLocalSection.ts
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
-import { updateResume } from "../redux/resumeSlice";
-import { useDispatch } from "react-redux";
+import { updateResume, updateResumeSection } from "../redux/resumeSlice";
 import type { OutcomeTypeSection, ResumeSection } from "../types/resume.type";
 import dayjs from "dayjs";
+import { useAppDispatch } from "./useAppDispatch";
 
 export const useLocalSection = <T extends ResumeSection>(
   section: T,
   onSave: () => void
 ) => {
   const [localSection, setLocalSection] = useState<T>(section);
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     setLocalSection(section);
@@ -49,8 +49,7 @@ export const useLocalSection = <T extends ResumeSection>(
     []
   );
   const SaveSection = () => {
-    dispatch(updateResume(localSection));
-    console.log("저장시", localSection);
+    dispatch(updateResumeSection(localSection));
     onSave();
   };
 

--- a/front-end/src/layout/ResumeSetupLayout .tsx
+++ b/front-end/src/layout/ResumeSetupLayout .tsx
@@ -12,23 +12,6 @@ import {
   titleStyle,
 } from "../styles/resumeCommonStyle";
 
-// interface Project {
-//   name: string;
-//   description: string;
-//   outcomes: string[];
-//   role: string;
-// }
-
-// interface GitInfo {
-//   introduction: {
-//     description: string;
-//   };
-//   projects: Project[];
-//   skills: {
-//     knowledgeable: string[];
-//     strengths: string[];
-//   };
-// }
 
 export interface ResumeContextType {
   isLoading: boolean;
@@ -56,7 +39,6 @@ export const ResumeSetupLayout = () => {
   const [selectedRepos, setSelectedRepos] = useState<
     { name: string; selected: boolean }[]
   >([]);
-  // const [gitInfo, setGitInfo] = useState<GitInfo | undefined>();
 
   const contextValue: ResumeContextType = {
     repoData,

--- a/front-end/src/page/resume/ResumeListPage.tsx
+++ b/front-end/src/page/resume/ResumeListPage.tsx
@@ -78,10 +78,20 @@ export const ResumeListPage = () => {
     setAnchorEl(null);
   };
 
-  const handleDelete = () => {};
+  const handleDelete = async (id: string) => {
+    const response = await fetch(`http://localhost:3000/resumes/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const result = await response.json();
+    console.log(result)
+
+  };
 
   useEffect(() => {
-    console.log("aaaa");
     const fetchResumes = async () => {
       try {
         const response = await fetch("http://localhost:3000/resumes", {
@@ -104,6 +114,8 @@ export const ResumeListPage = () => {
 
   const handleEntryResume = async (id: string) => {
     const result = await GetExistResume(id);
+
+    console.log(result)
     navigate(`/resume/${result.id}/editor`);
     dispatch(setResume(result));
   };
@@ -160,7 +172,7 @@ export const ResumeListPage = () => {
                 <MenuItem onClick={() => handleEntryResume(resume.id)}>
                   수정하기
                 </MenuItem>
-                <MenuItem onClick={handleDelete}>삭제하기 </MenuItem>
+                <MenuItem onClick={() => handleDelete(resume.id)}>삭제하기 </MenuItem>
               </Menu>
 
               <CardContent>

--- a/front-end/src/redux/resumeSlice.ts
+++ b/front-end/src/redux/resumeSlice.ts
@@ -1,7 +1,40 @@
-import { createSlice, type Draft, type PayloadAction } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice, type Draft, type PayloadAction } from "@reduxjs/toolkit";
 import { ResumeSection, ResumeData } from "../types/resume.type";
+import { updateSectionAPI } from "../api/UpdateSection";
 
 type ResumeState = ResumeData | null;
+
+export const updateResumeSection = createAsyncThunk<
+  ResumeSection,                  // fulfilled 타입
+  ResumeSection,                  // argument 타입
+  { state: { resumeInfo: ResumeData }; rejectValue: string } // thunkAPI 타입
+>("resume/updateSection",
+  async (section: ResumeSection, thunkAPI) => {
+    const stateBefore = thunkAPI.getState().resumeInfo;
+
+    // 로컬 상태 반영
+    thunkAPI.dispatch(updateResume(section));
+
+    try {
+      const updatedSection = await updateSectionAPI(section);
+
+      return updatedSection; // 서버 값이 다르면 state 갱신
+    } catch (error: any) {
+      console.error("서버 업데이트 실패:", error);
+
+      // 서버 실패 시 원래 값으로 복원
+      if (stateBefore) {
+        const originalSection = stateBefore.entities.find(s => s.id === section.id);
+        if (originalSection) {
+          thunkAPI.dispatch(updateResume(originalSection));
+        }
+      }
+
+      // rejected 액션으로 처리
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  }
+);
 
 // order에서 해당 id 찾아서 있으면, entitiy에서  해당 아이디로 들어가서 업데이트
 const resumeSlice = createSlice({
@@ -29,8 +62,26 @@ const resumeSlice = createSlice({
       if (!state) return;
       action.payload(state); // 내부에서 바로 수정 가능
     },
+    updateOrder(state, action: PayloadAction<string[]>) {
+      if (!state) return;
+      state.order = action.payload;
+    },
   },
+  extraReducers: builder => {
+    builder.addCase(updateResumeSection.fulfilled, (state, action) => {
+      if (!state) return;
+      // 서버에서 반환된 값과 로컬값이 다르면 갱신
+      state.entities = state.entities.map(section =>
+        section.id === action.payload.id ? action.payload : section
+      );
+    });
+
+    builder.addCase(updateResumeSection.rejected, (state, action) => {
+      console.error("Section update failed:", action.payload || action.error.message);
+      // 이미 Thunk 안에서 롤백 처리됨
+    });
+  }
 });
 
-export const { updateResume, setResume, addResume } = resumeSlice.actions;
+export const { updateResume, setResume, addResume, updateOrder } = resumeSlice.actions;
 export default resumeSlice.reducer;

--- a/front-end/src/redux/store.ts
+++ b/front-end/src/redux/store.ts
@@ -27,3 +27,4 @@ export const store = configureStore({
 
 export const persistor = persistStore(store);
 export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## 관련 이슈
-
## 변경 사항
- 이력서 부분저장시 redux createAsyncThunk로 api 연결하여 저장
- 기존 이력서 삭제 기능 구현

## 체크리스트
- [ ] 코드 리뷰를 완료했습니다.
- [ ] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
-