### PR TITLE
feater: 이력서 섹션 add/delete 로직 추가 및 서버 동기화

### DIFF
--- a/front-end/src/api/UpdateSection.tsx
+++ b/front-end/src/api/UpdateSection.tsx
@@ -1,6 +1,7 @@
 import { ResumeSection } from "../types/resume.type";
 
-export async function updateSectionAPI(section: ResumeSection) {
+export async function updateSectionAPI(section: ResumeSection, resumeId: string) {
+
     let sectionData;
     if (["profile", "introduction"].includes(section.type)) {
         const { id, ...withoutId } = section;
@@ -11,42 +12,59 @@ export async function updateSectionAPI(section: ResumeSection) {
         sectionData = { ...sectionData, githubUrl };
 
     }
-    let url = `http://localhost:3000/resumes/${section.id}`;
+    sectionData = section;
+    console.log(sectionData, "보내는 데이터")
+    let url = `http://localhost:3000/resumes/${resumeId}`;
     switch (section.type) {
         case "profile":
             url += "/profiles";
             break;
         case "skills":
-            url += "/api/skills";
+            url += "/skills";
             break;
         case "projects":
-            url += "/api/projects";
+            url += "/projects";
             break;
+        case "introduction":
+            url += "/introductions";
+            break;
+        case "careers":
+            url += "/careers";
+            break;
+        case "achievements":
+            url += "/achievements";
+            break;
+        case "custom":
+            url += "/customs";
+            break;
+
         default:
             throw new Error("Unknown section type");
     }
 
     try {
-        console.log(sectionData)
+        console.log(sectionData, "보내는 데이터")
         const response = await fetch(url, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             credentials: "include",
             body: JSON.stringify(sectionData),
         });
-
+        const updatedData = await response.json();
         if (!response.ok) {
             // 서버에서 에러 메시지 읽기
-            // console.log(errorData)
+            const error = new Error("Validation failed");
+
+            console.error("서버 에러 응답:", updatedData.validationErrors); // <- 여기서 backend JSON 확인 가능
+            (error as any).validationErrors = updatedData.validationErrors;
+            throw error;
         }
 
-        const updatedData = await response.json();
-        return { ...section, data: updatedData }; // 서버에서 받은 최신 데이터 포함
+
+        return { ...section }; // 서버에서 받은 최신 데이터 포함
     } catch (error: unknown) {
         if (error instanceof Error) {
             console.error("서버 에러 발생:", error);
-        } else {
-            console.error("알 수 없는 서버 에러:", error);
         }
         throw error; // 필요하면 상위에서 또 catch 가능
     }

--- a/front-end/src/components/resume/CreateSection.tsx
+++ b/front-end/src/components/resume/CreateSection.tsx
@@ -68,22 +68,22 @@ export const CreateSection = () => {
       const newItem: CareerItem | AchievementItem =
         type === "career"
           ? {
-              id: crypto.randomUUID(),
-              type: "career",
-              company: "",
-              position: "",
-              startDate: "",
-              endDate: "",
-              description: "",
-            }
+            id: crypto.randomUUID(),
+            type: "career",
+            company: "",
+            position: "",
+            startDate: "",
+            endDate: "",
+            description: "",
+          }
           : {
-              id: crypto.randomUUID(),
-              type: "achievement",
-              title: "",
-              organization: "",
-              date: "",
-              description: "",
-            };
+            id: crypto.randomUUID(),
+            type: "achievement",
+            title: "",
+            organization: "",
+            date: "",
+            description: "",
+          };
 
       dispatch(
         addResume((draft) => {
@@ -103,15 +103,15 @@ export const CreateSection = () => {
             const newSection =
               type === "career"
                 ? {
-                    id: crypto.randomUUID(),
-                    type: "careers" as const,
-                    items: [newItem as CareerItem],
-                  }
+                  id: "temp-" + crypto.randomUUID(),
+                  type: "careers" as const,
+                  items: [newItem as CareerItem],
+                }
                 : {
-                    id: crypto.randomUUID(),
-                    type: "achievements" as const,
-                    items: [newItem as AchievementItem],
-                  };
+                  id: crypto.randomUUID(),
+                  type: "achievements" as const,
+                  items: [newItem as AchievementItem],
+                };
 
             draft.entities.push(newSection);
             draft.order.push(newSection.id);
@@ -122,7 +122,7 @@ export const CreateSection = () => {
       // custom은 섹션 자체를 새로 추가
       const newSection = {
         ...sectionTemplates.custom,
-        id: crypto.randomUUID(),
+        id: "temp-" + crypto.randomUUID(),
       };
       dispatch(
         addResume((draft) => {

--- a/front-end/src/components/resume/sections/AchievementSection.tsx
+++ b/front-end/src/components/resume/sections/AchievementSection.tsx
@@ -34,7 +34,7 @@ export const AchievementSection = ({
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection, handleArrayItemChange } =
+  const { handleChange, SaveSection, localSection, handleArrayItemChange, DeleteSection } =
     useLocalSection(section, onSave);
   return (
     <SectionWrapper
@@ -42,6 +42,8 @@ export const AchievementSection = ({
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
+      onDelete={DeleteSection}
     >
       {localSection.items.map((section) => (
         <div

--- a/front-end/src/components/resume/sections/CareerSection.tsx
+++ b/front-end/src/components/resume/sections/CareerSection.tsx
@@ -32,7 +32,7 @@ export const CareerSection = ({
   onEdit,
   onSave,
 }: Props) => {
-  const { SaveSection, localSection, handleArrayItemChange } = useLocalSection(
+  const { SaveSection, localSection, handleArrayItemChange, DeleteSection } = useLocalSection(
     section,
     onSave
   );
@@ -43,6 +43,8 @@ export const CareerSection = ({
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
+      onDelete={DeleteSection}
     >
       {localSection.items.map((section) => (
         <div key={section.id}>

--- a/front-end/src/components/resume/sections/CustomSection.tsx
+++ b/front-end/src/components/resume/sections/CustomSection.tsx
@@ -27,7 +27,7 @@ export const CustomSection = ({
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection } = useLocalSection(
+  const { handleChange, SaveSection, localSection, DeleteSection } = useLocalSection(
     section,
     onSave
   );
@@ -58,6 +58,9 @@ export const CustomSection = ({
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
+      onDelete={DeleteSection}
+
     >
       {isEditing ? (
         <>

--- a/front-end/src/components/resume/sections/IntroductionSection.tsx
+++ b/front-end/src/components/resume/sections/IntroductionSection.tsx
@@ -44,6 +44,7 @@ export const IntroductionSection = ({
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
     >
       {isEditing ? (
         <>

--- a/front-end/src/components/resume/sections/ProfileSection.tsx
+++ b/front-end/src/components/resume/sections/ProfileSection.tsx
@@ -23,6 +23,7 @@ interface TextFieldProps {
   placeholder?: string;
   startAdornmentText?: string;
   onChange?: (value: string) => void;
+  error?: boolean;
 }
 const ProfileFieldInput = ({
   label,
@@ -30,6 +31,7 @@ const ProfileFieldInput = ({
   type,
   placeholder,
   onChange,
+  error,
   startAdornmentText,
 }: TextFieldProps) => {
   return (
@@ -41,6 +43,8 @@ const ProfileFieldInput = ({
       value={value}
       placeholder={placeholder}
       onChange={(e) => onChange?.(e.target.value)}
+      error={!!error && !value}
+      helperText={!!error && !value ? "필수값을 적어주세요." : ""}
       slotProps={
         startAdornmentText
           ? {
@@ -59,34 +63,34 @@ const ProfileFieldInput = ({
 export const ProfileSection = ({
   section,
   isEditing,
-  setSections,
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection } = useLocalSection(
+  const { handleChange, SaveSection, localSection, errors } = useLocalSection(
     section,
     onSave
   );
-
   return (
     <SectionWrapper
       title="기본 정보"
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
     >
       {isEditing ? (
         <>
           <div css={gridStyle}>
             <ProfileFieldInput
-              label="이름"
+              label="이름 *"
               value={localSection.name || ""}
               onChange={(v) => {
                 handleChange("name", v);
               }}
+              error={errors.name}
             />
             <ProfileFieldInput
-              label="이메일"
+              label="이메일 *"
               type="email"
               value={localSection.email || ""}
               onChange={(v) => {
@@ -94,7 +98,7 @@ export const ProfileSection = ({
               }}
             />
             <ProfileFieldInput
-              label="전화번호"
+              label="전화번호 *"
               type="tel"
               value={localSection.phoneNumber || ""}
               onChange={(v) => {
@@ -103,14 +107,14 @@ export const ProfileSection = ({
               placeholder="전화번호를 입력하세요"
             />
             <ProfileFieldInput
+              label="Github-URL"
               value={localSection.githubUrl || ""}
               onChange={(v) => {
                 handleChange("githubUrl", v);
               }}
-              startAdornmentText="github.com/"
             />
             <ProfileFieldInput
-              label="blog"
+              label="Blog-URL"
               value={localSection.blogUrl || ""}
               onChange={(v) => {
                 handleChange("blogUrl", v);
@@ -127,12 +131,14 @@ export const ProfileSection = ({
             />
           </div>
           <ProfileFieldInput
-            label="주소"
+            label="주소 *"
             type="address"
-            value={localSection.address || ""}
+            value={localSection.address}
             onChange={(v) => {
               handleChange("address", v);
             }}
+            error={errors.address}
+
           />
         </>
       ) : (

--- a/front-end/src/components/resume/sections/ProjectsSection.tsx
+++ b/front-end/src/components/resume/sections/ProjectsSection.tsx
@@ -34,13 +34,13 @@ export const ProjectsSection = ({
   const { handleChange, SaveSection, localSection, handleArrayItemChange } =
     useLocalSection(section, onSave);
 
-  console.log(localSection);
   return (
     <SectionWrapper
       title="프로젝트"
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={SaveSection}
+      sectionType={section.type}
     >
       {localSection.items.map((project) => (
         <div key={project.id} css={{ marginBottom: "2rem" }}>

--- a/front-end/src/components/resume/sections/SectionWrapper.tsx
+++ b/front-end/src/components/resume/sections/SectionWrapper.tsx
@@ -17,9 +17,11 @@ const titleStyle = css`
 `;
 export const SectionWrapper = ({
   title,
+  isEditing,
   onEdit,
   onSave,
-  isEditing,
+  onDelete,
+  sectionType, // 추가
   children,
 }: {
   title: React.ReactNode;
@@ -27,9 +29,8 @@ export const SectionWrapper = ({
   onEdit: () => void;
   onSave: () => void;
   onDelete?: () => void;
+  sectionType?: string;
   children: React.ReactNode;
-
-
 }) => {
 
   return (
@@ -46,7 +47,12 @@ export const SectionWrapper = ({
           marginTop: "2rem",
         }}
       >
-        {isEditing && <Button>삭제</Button>}
+        {isEditing &&
+          (sectionType === "custom" ||
+            sectionType === "careers" ||
+            sectionType === "achievements") && (
+            <Button onClick={onDelete}>삭제</Button>
+          )}
         <Button
           css={css`
             margin-left: auto;

--- a/front-end/src/components/resume/sections/SkillsSection.tsx
+++ b/front-end/src/components/resume/sections/SkillsSection.tsx
@@ -37,7 +37,6 @@ type skill = {
 export const SkillsSection = ({
   section,
   isEditing,
-  setSections,
   onEdit,
   onSave,
 }: Props) => {
@@ -112,6 +111,7 @@ export const SkillsSection = ({
       isEditing={isEditing}
       onEdit={onEdit}
       onSave={onSave}
+      sectionType={section.type}
     >
       {isEditing ? (
         <>

--- a/front-end/src/hooks/useLocalSection.ts
+++ b/front-end/src/hooks/useLocalSection.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { updateResume, updateResumeSection } from "../redux/resumeSlice";
+import { removeSection, updateResume, updateResumeSection } from "../redux/resumeSlice";
 import type { OutcomeTypeSection, ResumeSection } from "../types/resume.type";
 import dayjs from "dayjs";
 import { useAppDispatch } from "./useAppDispatch";
+import { useDispatch, useSelector } from "react-redux";
+
 
 export const useLocalSection = <T extends ResumeSection>(
   section: T,
@@ -10,13 +12,17 @@ export const useLocalSection = <T extends ResumeSection>(
 ) => {
   const [localSection, setLocalSection] = useState<T>(section);
   const dispatch = useAppDispatch();
+  const localDispatch = useDispatch();
+  const resumeId = useSelector((state: { resumeInfo: { id: string; }; }) => state.resumeInfo?.id);
+  const [errors, setErrors] = useState<{ [key: string]: boolean }>({});
 
   useEffect(() => {
     setLocalSection(section);
+    console.log(section)
   }, [section]);
 
   const handleChange = useCallback(
-    (key: string, value: number | string | typeof dayjs) => {
+    (key: string, value: number | string | typeof dayjs | undefined) => {
       setLocalSection((prev) => ({
         ...prev,
         [key]: value,
@@ -34,7 +40,6 @@ export const useLocalSection = <T extends ResumeSection>(
     ) => {
       setLocalSection((prev) => {
         const array = (prev as any)[key];
-        console.log(array, key);
         if (Array.isArray(array)) {
           return {
             ...prev,
@@ -48,10 +53,53 @@ export const useLocalSection = <T extends ResumeSection>(
     },
     []
   );
-  const SaveSection = () => {
-    dispatch(updateResumeSection(localSection));
-    onSave();
-  };
+  const removeTempPrefix = (id: string) => id.startsWith("temp-") ? id.slice(5) : id;
 
-  return { handleChange, SaveSection, localSection, handleArrayItemChange };
+  const SaveSection = async () => {
+    // 타입이 careers, achievements, custom인 경우 id에서 temp- 제거
+    let sectionToSave: any = localSection;
+    if (
+      localSection.type === "careers" ||
+      localSection.type === "achievements" ||
+      localSection.type === "custom"
+    ) {
+      sectionToSave = {
+        ...localSection,
+        id: removeTempPrefix(localSection.id),
+      };
+    }
+    try {
+      await dispatch(updateResumeSection(sectionToSave)).unwrap();
+      setErrors({}); // 성공 시 에러 초기화
+      onSave();
+    } catch (error: any) {
+      const fieldErrors: { [key: string]: boolean } = {};
+
+      error.forEach((err: { field: string }) => {
+        fieldErrors[err.field] = true; // true면 빨간 테두리
+      });
+      setErrors(fieldErrors);
+    }
+  }
+  const DeleteSection = async () => {
+    if (section.id.startsWith("temp-")) {
+      // setResume을 dispatch해서 로컬 상태만 업데이트
+      localDispatch(removeSection(section.id));
+      return;
+    }
+    try {
+      const response = await fetch(`http://localhost:3000/resumes/${resumeId}/${section.type}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+      },
+      );
+      if (!response.ok) {
+        throw new Error("Failed to delete section");
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+  return { handleChange, SaveSection, localSection, handleArrayItemChange, errors, DeleteSection };
 };

--- a/front-end/src/page/resume/GitConnectPage.tsx
+++ b/front-end/src/page/resume/GitConnectPage.tsx
@@ -48,9 +48,9 @@ export const GitConnectPage = () => {
       // Check if the request was successful
       if (!response.ok) {
         const errorData = await response.json();
+        console.error(errorData)
         throw new Error(
-          `HTTP error! status: ${response.status}, message: ${
-            errorData.message || "Unknown error"
+          `HTTP error! status: ${response.status}, message: ${errorData.message || "Unknown error"
           }`
         );
       }

--- a/front-end/src/page/resume/ResumeListPage.tsx
+++ b/front-end/src/page/resume/ResumeListPage.tsx
@@ -44,6 +44,8 @@ type ProfileType = {
 export const ResumeListPage = () => {
   const [resumes, setResumes] = useState<ResumeSummary[]>([]);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -71,8 +73,9 @@ export const ResumeListPage = () => {
     fetchResumes(id);
   };
 
-  const handleOption = (e: React.MouseEvent<HTMLElement>) => {
+  const handleOption = (e: React.MouseEvent<HTMLElement>, id: string) => {
     setAnchorEl(e.currentTarget);
+    setSelectedId(id);
   };
   const handleClose = () => {
     setAnchorEl(null);
@@ -103,6 +106,7 @@ export const ResumeListPage = () => {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         const data = await response.json();
+        console.log(data)
         setResumes(data);
       } catch (error) {
         console.error("이력서 리스트 가져오기 실패:", error);
@@ -169,10 +173,10 @@ export const ResumeListPage = () => {
                   },
                 }}
               >
-                <MenuItem onClick={() => handleEntryResume(resume.id)}>
+                <MenuItem onClick={() => selectedId && handleEntryResume(selectedId)}>
                   수정하기
                 </MenuItem>
-                <MenuItem onClick={() => handleDelete(resume.id)}>삭제하기 </MenuItem>
+                <MenuItem onClick={() => selectedId && handleDelete(selectedId)}>삭제하기 </MenuItem>
               </Menu>
 
               <CardContent>
@@ -185,7 +189,7 @@ export const ResumeListPage = () => {
                   <Typography variant="h6" fontWeight={600}>
                     {resume.title}
                   </Typography>
-                  <IconButton onClick={handleOption}>
+                  <IconButton onClick={(e) => handleOption(e, resume.id)}>
                     <MoreVertIcon />
                   </IconButton>
                 </div>
@@ -242,6 +246,6 @@ export const ResumeListPage = () => {
           </Grid>
         ))}
       </Grid>
-    </Box>
+    </Box >
   );
 };

--- a/front-end/src/redux/resumeSlice.ts
+++ b/front-end/src/redux/resumeSlice.ts
@@ -16,7 +16,7 @@ export const updateResumeSection = createAsyncThunk<
     thunkAPI.dispatch(updateResume(section));
 
     try {
-      const updatedSection = await updateSectionAPI(section);
+      const updatedSection = await updateSectionAPI(section, stateBefore.id);
 
       return updatedSection; // 서버 값이 다르면 state 갱신
     } catch (error: any) {
@@ -28,6 +28,10 @@ export const updateResumeSection = createAsyncThunk<
         if (originalSection) {
           thunkAPI.dispatch(updateResume(originalSection));
         }
+      }
+
+      if (error.validationErrors) {
+        return thunkAPI.rejectWithValue(error.validationErrors);
       }
 
       // rejected 액션으로 처리
@@ -66,6 +70,11 @@ const resumeSlice = createSlice({
       if (!state) return;
       state.order = action.payload;
     },
+    removeSection(state, action: PayloadAction<string>) {
+      if (!state) return;
+      state.entities = state.entities.filter(section => section.id !== action.payload);
+      state.order = state.order.filter(id => id !== action.payload);
+    },
   },
   extraReducers: builder => {
     builder.addCase(updateResumeSection.fulfilled, (state, action) => {
@@ -83,5 +92,5 @@ const resumeSlice = createSlice({
   }
 });
 
-export const { updateResume, setResume, addResume, updateOrder } = resumeSlice.actions;
+export const { updateResume, setResume, addResume, updateOrder, removeSection } = resumeSlice.actions;
 export default resumeSlice.reducer;


### PR DESCRIPTION
## 관련 이슈
-

## 변경 사항
- 새 섹션 생성 시 id에 'temp-' prefix를 붙여 서버 저장 전/후를 구분
- 저장 시 careers, achievements, custom 타입의 id에서 'temp-' prefix를 제거해 서버로 전송
- 삭제 시 id가 'temp-'로 시작하면 서버 API 호출 없이 Redux 상태만 갱신
- 필수 섹션시에 삭제 버튼 예외처리
- 기타 불필요한 type 필드 및 구조 오류 수정
- 
## 체크리스트
- [x] 코드 리뷰를 완료했습니다.
- [x] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
-