### PR TITLE
refactor: 프로젝트-스킬 관계 제거 및 코드 정리

### DIFF
--- a/back-end/src/resume/dto/create-project.dto.ts
+++ b/back-end/src/resume/dto/create-project.dto.ts
@@ -8,7 +8,6 @@ import {
 } from 'class-validator';
 import { CreateOutcomeDto } from './create-project-outcome.dto';
 import { Type } from 'class-transformer';
-import { CreateSkillDto } from './create-skill.dto';
 
 export class CreateProjectDto {
 
@@ -27,11 +26,6 @@ export class CreateProjectDto {
   @IsOptional()
   @IsDateString()
   endDate?: string;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => CreateSkillDto)
-  skills: CreateSkillDto[];
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -1,14 +1,11 @@
 import {
   Column,
   Entity,
-  JoinTable,
-  ManyToMany,
   ManyToOne,
   OneToMany,
 } from 'typeorm';
 import { ResumeModel } from './resume.entity';
 import { ProjectOutcomeModel } from './project-outcome.entity';
-import { SkillModel } from './skill.entity';
 import { BaseUuidModel } from 'src/common/entity/base.entity';
 
 @Entity()
@@ -31,12 +28,4 @@ export class ProjectModel extends BaseUuidModel {
 
   @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project, { cascade: true })
   outcomes: ProjectOutcomeModel[];
-
-  @ManyToMany(() => SkillModel, { cascade: true })
-  @JoinTable({
-    name: 'project_skills',
-    joinColumn: { name: 'project_id', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'skill_id', referencedColumnName: 'id' },
-  })
-  skills: SkillModel[];
 }

--- a/back-end/src/resume/entities/skill.entity.ts
+++ b/back-end/src/resume/entities/skill.entity.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, ManyToMany } from 'typeorm';
 import { ResumeModel } from './resume.entity';
-import { ProjectModel } from './project.entity';
 import { BaseModel } from 'src/common/entity/base.entity';
 
 @Entity()
@@ -17,8 +16,5 @@ export class SkillModel extends BaseModel {
 
   @ManyToMany(() => ResumeModel, (resume) => resume.fam_skills, { onDelete: 'CASCADE' })
   familiarResumes: ResumeModel[];
-
-  @ManyToMany(() => ProjectModel, (project) => project.skills, { onDelete: 'CASCADE' })
-  projects: ProjectModel[];
   
 }

--- a/back-end/src/resume/resumeGeneration.Service.ts
+++ b/back-end/src/resume/resumeGeneration.Service.ts
@@ -64,7 +64,6 @@ export class ResumeGenerationService {
       }),
     );
     const familiar = familiarRaw.filter(Boolean);
-
     await this.resumeService.saveBlock(resume.id, {
       type: "skills",
       strongSkillIds: strengths.map((s) => s.id),
@@ -72,21 +71,6 @@ export class ResumeGenerationService {
     });
 
     const projects = resumeData.projects;
-
-    for (const project of resumeData.projects) {
-      const matchedSkillIds = (
-        await Promise.all(
-          (project.skills || []).map(async (skillName) => {
-            const [result] = await this.resumeService.searchSkills(skillName);
-
-            return result ? result.id : undefined;
-          }),
-        )
-      ).filter(Boolean);
-
-      project.skills = matchedSkillIds;
-    }
-
     await this.resumeService.saveBlock(
       resume.id,
       {
@@ -121,7 +105,6 @@ Using the following GitHub profile data, generate a structured JSON object for a
       "description": "", // Brief description of the project in Korean.
       "startDate": "", // Start date of the project (if available).
       "endDate": "", // End date of the project (if available).
-      "skills": [], // List of skill IDs used in the project.
       "outcomes": [
         {
           "task": "", // A short title in Korean summarizing the task or achievement (e.g., "구글 인증 구현").


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- ProjectModel에서 skills 컬럼 및 ManyToMany 관계 제거
- CreateProjectDto에서 skills 필드 제거
- ResumeService.upsertProject에서 스킬 관련 로직 제거
- ResumeGenerationService에서 프로젝트 스킬 매칭 로직 제거
- 코드 단순화 및 불필요한 복잡성 제거

## 체크리스트
- [ o] 코드 리뷰를 완료했습니다.

## 기타 참고 사항
- 
