### PR TITLE
refactor: 저장시 섹션 유효성 검사 로직 개선 및 textfield에 error/helpertext 적용

### DIFF
--- a/front-end/src/api/UpdateSection.tsx
+++ b/front-end/src/api/UpdateSection.tsx
@@ -2,18 +2,9 @@ import { ResumeSection } from "../types/resume.type";
 
 export async function updateSectionAPI(section: ResumeSection, resumeId: string) {
 
-    let sectionData;
-    if (["profile", "introduction"].includes(section.type)) {
-        const { id, ...withoutId } = section;
-        sectionData = withoutId
-    }
-    if (sectionData && sectionData.type === "profile") {
-        const githubUrl = "https://github.com/" + sectionData.githubUrl;
-        sectionData = { ...sectionData, githubUrl };
+    let sectionData: ResumeSection = section;
 
-    }
-    sectionData = section;
-    console.log(sectionData, "보내는 데이터")
+
     let url = `http://localhost:3000/resumes/${resumeId}`;
     switch (section.type) {
         case "profile":

--- a/front-end/src/components/resume/ResumeEditorPanel.tsx
+++ b/front-end/src/components/resume/ResumeEditorPanel.tsx
@@ -40,7 +40,7 @@ export const ResumeEditorPanel = ({
       onSave: () => onSave(section.id),
     };
 
-    switch (section.type) {
+    switch (section?.type) {
       case "profile":
         return (
           <ProfileSection key={section.id} section={section} {...common} />

--- a/front-end/src/components/resume/ResumePreviewPanel.tsx
+++ b/front-end/src/components/resume/ResumePreviewPanel.tsx
@@ -382,34 +382,6 @@ export const ResumePreviewPanel = forwardRef<HTMLDivElement, Props>(
                         {i.description}
                       </p>
 
-                      {/* 기술 스택 */}
-                      {i.skills?.length > 0 && (
-                        <div
-                          css={css`
-                            display: flex;
-                            flex-wrap: wrap;
-                            gap: 6px;
-                            margin-bottom: 12px;
-                          `}
-                        >
-                          {i.skills.map((skill, sIdx) => (
-                            <span
-                              key={sIdx}
-                              css={css`
-                                font-size: 13px;
-                                padding: 4px 10px;
-                                border-radius: 9999px;
-                                // background: #e0f2fe; /* 파란색 계열 */
-                                color: #465a80;
-                                font-weight: 500;
-                              `}
-                            >
-                              {skill}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-
                       {/* 한일 & 성과 */}
                       {i.outcomes.map((t: OutcomeTypeSection, oIdx: number) => (
                         <div

--- a/front-end/src/components/resume/sections/AchievementSection.tsx
+++ b/front-end/src/components/resume/sections/AchievementSection.tsx
@@ -34,7 +34,7 @@ export const AchievementSection = ({
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection, handleArrayItemChange, DeleteSection } =
+  const { SaveSection, localSection, handleArrayItemChange, DeleteSection, errors } =
     useLocalSection(section, onSave);
   return (
     <SectionWrapper
@@ -45,7 +45,7 @@ export const AchievementSection = ({
       sectionType={section.type}
       onDelete={DeleteSection}
     >
-      {localSection.items.map((section) => (
+      {localSection.items.map((section, idx) => (
         <div
           css={css`
             // padding: 2rem;
@@ -62,7 +62,7 @@ export const AchievementSection = ({
                 `}
               >
                 <TextField
-                  label="항목명"
+                  label="항목명 *"
                   value={section.title}
                   security=""
                   onChange={(e) =>
@@ -73,12 +73,14 @@ export const AchievementSection = ({
                       e.target.value
                     )
                   }
+                  error={errors[`items_${idx}_title`] && !section.title}
+                  helperText={errors[`items_${idx}_title`] ? "필수값을 적어주세요." : ""}
                   fullWidth
                   size="small"
                   margin="dense"
                 />
                 <TextField
-                  label="발행기관"
+                  label="발행기관 *"
                   value={section.organization}
                   onChange={(e) =>
                     handleArrayItemChange(
@@ -88,6 +90,8 @@ export const AchievementSection = ({
                       e.target.value
                     )
                   }
+                  error={errors[`items_${idx}_organization`] && !section.organization}
+                  helperText={errors[`items_${idx}_organization`] ? "필수값을 적어주세요." : ""}
                   fullWidth
                   size="small"
                   margin="dense"
@@ -96,7 +100,7 @@ export const AchievementSection = ({
               <div>
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
                   <DatePicker
-                    label="취득일"
+                    label="취득일 *"
                     value={section.date ? dayjs(section.date) : null}
                     onChange={(newValue) => {
                       if (newValue) {
@@ -113,6 +117,8 @@ export const AchievementSection = ({
                       textField: {
                         fullWidth: true,
                         size: "small",
+                        error: errors[`items_${idx}_date`] && !section.date ? true : false,
+                        helperText: errors[`items_${idx}_date`] ? "필수값을 적어주세요." : "",
                       },
                     }}
                   />

--- a/front-end/src/components/resume/sections/CareerSection.tsx
+++ b/front-end/src/components/resume/sections/CareerSection.tsx
@@ -28,11 +28,10 @@ interface Props {
 export const CareerSection = ({
   section,
   isEditing,
-  setSections,
   onEdit,
   onSave,
 }: Props) => {
-  const { SaveSection, localSection, handleArrayItemChange, DeleteSection } = useLocalSection(
+  const { SaveSection, localSection, handleArrayItemChange, DeleteSection, errors } = useLocalSection(
     section,
     onSave
   );
@@ -46,7 +45,7 @@ export const CareerSection = ({
       sectionType={section.type}
       onDelete={DeleteSection}
     >
-      {localSection.items.map((section) => (
+      {localSection.items.map((section, idx) => (
         <div key={section.id}>
           {isEditing ? (
             <div
@@ -76,7 +75,9 @@ export const CareerSection = ({
                     )
                   }
                   placeholder="회사명을 입력하세요"
-                  label="회사 명"
+                  label="회사 명 *"
+                  error={errors[`items_${idx}_company`] && !section.company}
+                  helperText={errors[`items_${idx}_company`] ? "필수값을 적어주세요." : ""}
                 />
                 <TextField
                   multiline
@@ -90,11 +91,13 @@ export const CareerSection = ({
                       e.target.value
                     )
                   }
-                  label="직무"
+                  label="직무 *"
+                  error={errors[`items_${idx}_position`] && !section.position}
+                  helperText={errors[`items_${idx}_position`] ? "필수값을 적어주세요." : ""}
                 />
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
                   <DatePicker
-                    label="입사년월"
+                    label="입사년월 *"
                     css={textFieldStyle}
                     value={section.startDate ? dayjs(section.startDate) : null}
                     onChange={(newValue) => {
@@ -107,6 +110,12 @@ export const CareerSection = ({
                           formattedDate
                         );
                       }
+                    }}
+                    slotProps={{
+                      textField: {
+                        error: errors[`items_${idx}_startDate`] && !section.startDate,
+                        helperText: errors[`items_${idx}_startDate`] ? "필수값을 적어주세요." : "",
+                      },
                     }}
                   />
                   <DatePicker
@@ -134,7 +143,7 @@ export const CareerSection = ({
               >
                 <TextField
                   multiline
-                  label="담당업무"
+                  label="담당업무 *"
                   css={css`
                     width: 100%;
                     box-sizing: border-box;
@@ -148,6 +157,8 @@ export const CareerSection = ({
                       e.target.value
                     )
                   }
+                  error={errors[`items_${idx}_description`] && !section.description}
+                  helperText={errors[`items_${idx}_description`] ? "필수값을 적어주세요." : ""}
                 />
               </div>
             </>

--- a/front-end/src/components/resume/sections/CustomSection.tsx
+++ b/front-end/src/components/resume/sections/CustomSection.tsx
@@ -27,7 +27,7 @@ export const CustomSection = ({
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection, DeleteSection } = useLocalSection(
+  const { handleChange, SaveSection, localSection, DeleteSection, errors } = useLocalSection(
     section,
     onSave
   );
@@ -48,6 +48,8 @@ export const CustomSection = ({
             }}
             placeholder="섹션 제목을 입력하세요"
             fullWidth
+            error={!!errors.title && !localSection.title}
+            helperText={errors.title ? "필수값을 적어주세요." : ""}
           />
         ) : (
           <Typography variant="h5">
@@ -73,6 +75,8 @@ export const CustomSection = ({
               handleChange("description", e.target.value);
             }}
             minRows={4}
+            error={!!errors.description && !localSection.description}
+            helperText={errors.description ? "필수값을 적어주세요." : ""}
           />
         </>
       ) : (

--- a/front-end/src/components/resume/sections/IntroductionSection.tsx
+++ b/front-end/src/components/resume/sections/IntroductionSection.tsx
@@ -30,11 +30,10 @@ interface Props {
 export const IntroductionSection = ({
   section,
   isEditing,
-  setSections,
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection } = useLocalSection(
+  const { handleChange, SaveSection, localSection, errors } = useLocalSection(
     section,
     onSave
   );
@@ -55,6 +54,8 @@ export const IntroductionSection = ({
             onChange={(e) => {
               handleChange("headline", e.target.value);
             }}
+            error={!!errors.headline && !localSection.headline}
+            helperText={errors.headline ? "필수값을 적어주세요." : ""}
             placeholder="제목을 입력하세요"
           />
           <TextField
@@ -65,6 +66,8 @@ export const IntroductionSection = ({
               handleChange("description", e.target.value);
             }}
             placeholder="자기소개를 입력하세요"
+            error={!!errors.description && !localSection.description}
+            helperText={errors.description ? "필수값을 적어주세요." : ""}
           />
         </>
       ) : (

--- a/front-end/src/components/resume/sections/ProfileSection.tsx
+++ b/front-end/src/components/resume/sections/ProfileSection.tsx
@@ -96,6 +96,7 @@ export const ProfileSection = ({
               onChange={(v) => {
                 handleChange("email", v);
               }}
+              error={errors.email}
             />
             <ProfileFieldInput
               label="전화번호 *"
@@ -105,6 +106,8 @@ export const ProfileSection = ({
                 handleChange("phoneNumber", v);
               }}
               placeholder="전화번호를 입력하세요"
+              error={errors.phoneNumber}
+
             />
             <ProfileFieldInput
               label="Github-URL"
@@ -138,7 +141,6 @@ export const ProfileSection = ({
               handleChange("address", v);
             }}
             error={errors.address}
-
           />
         </>
       ) : (

--- a/front-end/src/components/resume/sections/ProjectsSection.tsx
+++ b/front-end/src/components/resume/sections/ProjectsSection.tsx
@@ -27,11 +27,10 @@ interface Props {
 export const ProjectsSection = ({
   section,
   isEditing,
-  setSections,
   onEdit,
   onSave,
 }: Props) => {
-  const { handleChange, SaveSection, localSection, handleArrayItemChange } =
+  const { SaveSection, localSection, handleArrayItemChange, errors } =
     useLocalSection(section, onSave);
 
   return (
@@ -42,7 +41,7 @@ export const ProjectsSection = ({
       onSave={SaveSection}
       sectionType={section.type}
     >
-      {localSection.items.map((project) => (
+      {localSection.items.map((project, idx) => (
         <div key={project.id} css={{ marginBottom: "2rem" }}>
           {isEditing ? (
             <section
@@ -63,13 +62,11 @@ export const ProjectsSection = ({
               >
                 <div
                   css={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr",
                     gap: "1rem",
                   }}
                 >
                   <TextField
-                    label="프로젝트명"
+                    label="프로젝트명 *"
                     value={project.name}
                     fullWidth
                     onChange={(e) =>
@@ -82,24 +79,8 @@ export const ProjectsSection = ({
                     }
                     size="small"
                     margin="dense"
-                  />
-                  <TextField
-                    label="사용 기술"
-                    value={project.skills?.join(", ")}
-                    fullWidth
-                    size="small"
-                    onChange={(e) =>
-                      handleArrayItemChange(
-                        "items",
-                        project.id,
-                        "skills",
-                        e.target.value
-                      )
-                    }
-                    margin="dense"
-                    multiline
-                    minRows={2}
-                    placeholder="예: React, TypeScript, NestJS"
+                    error={errors[`items_${idx}_name`] && !project.name}
+                    helperText={errors[`items_${idx}_name`] ? "필수값을 적어주세요." : ""}
                   />
                 </div>
                 <div
@@ -110,7 +91,7 @@ export const ProjectsSection = ({
                   }}
                 >
                   <TextField
-                    label="시작일"
+                    label="시작일 *"
                     value={project.startDate}
                     onChange={(e) =>
                       handleArrayItemChange(
@@ -120,6 +101,8 @@ export const ProjectsSection = ({
                         e.target.value
                       )
                     }
+                    error={errors[`items_${idx}_startDate`] && !project.startDate}
+                    helperText={errors[`items_${idx}_startDate`] ? "필수값을 적어주세요." : ""}
                     fullWidth
                     size="small"
                     margin="dense"
@@ -141,7 +124,7 @@ export const ProjectsSection = ({
                   />
                 </div>
                 <TextField
-                  label="설명"
+                  label="설명 *"
                   value={project.description}
                   onChange={(e) =>
                     handleArrayItemChange(
@@ -156,6 +139,8 @@ export const ProjectsSection = ({
                   margin="dense"
                   multiline
                   minRows={3}
+                  error={errors[`items_${idx}_description`] && !project.description}
+                  helperText={errors[`items_${idx}_description`] ? "필수값을 적어주세요." : ""}
                 />
                 {project.outcomes.length > 0 && (
                   <div
@@ -175,9 +160,9 @@ export const ProjectsSection = ({
                       관련 성과
                     </Typography>
 
-                    {project.outcomes.map((outcome) => (
+                    {project.outcomes.map((outcome, oIdx) => (
                       <div
-                        key={outcome.id}
+                        key={oIdx}
                         css={{
                           borderRadius: "8px",
                           padding: "1rem",
@@ -187,7 +172,7 @@ export const ProjectsSection = ({
                         }}
                       >
                         <TextField
-                          label="한 일"
+                          label="한 일 *"
                           value={outcome.task}
                           onChange={(e) =>
                             handleArrayItemChange(
@@ -201,6 +186,8 @@ export const ProjectsSection = ({
                               )
                             )
                           }
+                          error={errors[`items_${idx}_outcomes_${oIdx}_task`] && !outcome.task}
+                          helperText={errors[`items_${idx}_outcomes_${oIdx}_task`] ? "필수값을 적어주세요." : ""}
                           fullWidth
                           size="small"
                           margin="dense"
@@ -211,7 +198,7 @@ export const ProjectsSection = ({
                           }}
                         />
                         <TextField
-                          label="성과"
+                          label="성과 *"
                           value={outcome.result}
                           sx={{
                             backgroundColor: "#fff",
@@ -228,6 +215,8 @@ export const ProjectsSection = ({
                               )
                             )
                           }
+                          error={errors[`items_${idx}_outcomes_${oIdx}_result`] && !outcome.result}
+                          helperText={errors[`items_${idx}_outcomes_${oIdx}_result`] ? "필수값을 적어주세요." : ""}
                           fullWidth
                           size="small"
                           margin="dense"
@@ -249,8 +238,6 @@ export const ProjectsSection = ({
               <Typography>
                 기간: {project.startDate} ~ {project.endDate}
               </Typography>
-              <Typography>사용 기술: {project.skills.join(", ")}</Typography>
-
               {project.outcomes.length > 0 && (
                 <div css={{ marginTop: "1rem" }}>
                   <Typography

--- a/front-end/src/hooks/useLocalSection.ts
+++ b/front-end/src/hooks/useLocalSection.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { removeSection, updateResume, updateResumeSection } from "../redux/resumeSlice";
+import { removeSection, updateResumeSection } from "../redux/resumeSlice";
 import type { OutcomeTypeSection, ResumeSection } from "../types/resume.type";
 import dayjs from "dayjs";
 import { useAppDispatch } from "./useAppDispatch";
 import { useDispatch, useSelector } from "react-redux";
+import { validateRequiredFields } from "../utils/validateSectionFields";
 
 
 export const useLocalSection = <T extends ResumeSection>(
@@ -55,7 +56,15 @@ export const useLocalSection = <T extends ResumeSection>(
   );
   const removeTempPrefix = (id: string) => id.startsWith("temp-") ? id.slice(5) : id;
 
+
   const SaveSection = async () => {
+    const fieldErrors = validateRequiredFields(localSection);
+    console.log(fieldErrors, "필수값 체크 결과")
+    if (Object.keys(fieldErrors).length > 0) {
+      console.log("필수값 체크 에러:", fieldErrors);
+      setErrors(fieldErrors);
+      return;
+    }
     // 타입이 careers, achievements, custom인 경우 id에서 temp- 제거
     let sectionToSave: any = localSection;
     if (
@@ -73,12 +82,7 @@ export const useLocalSection = <T extends ResumeSection>(
       setErrors({}); // 성공 시 에러 초기화
       onSave();
     } catch (error: any) {
-      const fieldErrors: { [key: string]: boolean } = {};
 
-      error.forEach((err: { field: string }) => {
-        fieldErrors[err.field] = true; // true면 빨간 테두리
-      });
-      setErrors(fieldErrors);
     }
   }
   const DeleteSection = async () => {

--- a/front-end/src/page/resume/EditResumePage.tsx
+++ b/front-end/src/page/resume/EditResumePage.tsx
@@ -129,7 +129,7 @@ export const EditResumePage = () => {
       .set(opt)
       .from(element)
       .save()
-      .catch((err) => console.error(err));
+      .catch((err: any) => console.error(err));
   };
 
   const [open, setOpen] = useState(false);

--- a/front-end/src/types/resume.type.ts
+++ b/front-end/src/types/resume.type.ts
@@ -16,7 +16,6 @@ export type ResumeSection =
   | CareersTypeSection
   | AchievementsTypeSection
   | ProjectTypeSection
-  | OutcomeTypeSection
   | IntroductionTypeSection
   | CustomTypeSection
   | ProjectsTypeSection;
@@ -65,18 +64,11 @@ export type CareersTypeSection = {
   id: string;
   type: "careers";
   items: CareerItem[];
-  // company: string;
-  // position: string;
-  // startDate: string;
-  // endDate: string;
-  // isCurrent: boolean;
-  // description: string;
-  // technologies: string[];
 };
 
 export type CareerItem = {
   id: string;
-  type: "career";
+  // type: "career";
   company: string;
   position: string;
   startDate: string;
@@ -89,15 +81,11 @@ export type AchievementsTypeSection = {
   id: string;
   type: "achievements";
   items: AchievementItem[];
-  // title: string;
-  // organization: string;
-  // date: string;
-  // description?: string;
+
 };
 
 export type AchievementItem = {
   id: string;
-  type: "achievement";
   title: string;
   organization: string;
   date: string;
@@ -111,7 +99,6 @@ export type ProjectTypeSection = {
   description: string;
   startDate: string;
   endDate?: string;
-  skills: string[];
   outcomes: OutcomeTypeSection[];
 };
 
@@ -123,7 +110,6 @@ export type ProjectsTypeSection = {
 
 export type OutcomeTypeSection = {
   id: string;
-  type: "outcome";
   task: string;
   result: string;
 };

--- a/front-end/src/utils/validateSectionFields.ts
+++ b/front-end/src/utils/validateSectionFields.ts
@@ -1,0 +1,80 @@
+import type { ResumeSection } from "../types/resume.type";
+
+// 섹션별 필수값
+export const requiredFieldsMap: Record<ResumeSection["type"], string[]> = {
+    profile: ["name", "email", "phoneNumber", "address"],
+    skills: ["familiars", "strengths"],
+    careers: ["items"],
+    achievements: ["items"],
+    project: ["name", "description", "startDate", "outcomes"],
+    projects: ["items"],
+    introduction: ["headline", "description"],
+    custom: ["title", "description"],
+};
+
+// items 내부 필수값
+export const itemRequiredFieldsMap: Partial<Record<ResumeSection["type"], string[]>> = {
+    careers: ["company", "position", "startDate", "description"],
+    achievements: ["title", "organization", "date"],
+    projects: ["name", "description", "startDate", "outcomes"],
+};
+
+// outcomes 내부 필수값
+export const outcomeRequiredFields = ["task", "result"];
+
+// 공통 빈값 체크 함수
+function isEmpty(value: any) {
+    return (
+        value === undefined ||
+        value === null ||
+        value === "" ||
+        (Array.isArray(value) && value.length === 0)
+    );
+}
+
+// 필수값 검증 함수
+export function validateRequiredFields(section: ResumeSection) {
+    const fieldErrors: { [key: string]: boolean } = {};
+
+    //섹션 자체 필수값 체크
+    (requiredFieldsMap[section.type] || []).forEach((field) => {
+        if (isEmpty(section[field as keyof typeof section])) {
+            fieldErrors[field] = true;
+        }
+    });
+
+    //items 내부 필수값 체크
+    if ("items" in section && Array.isArray(section.items)) {
+        const itemFields = itemRequiredFieldsMap[section.type] || [];
+        section.items.forEach((item: any, idx: number) => {
+            itemFields.forEach((field) => {
+                if (isEmpty(item[field])) {
+                    fieldErrors[`items_${idx}_${field}`] = true;
+                }
+            });
+            // projects의 outcomes 배열 내부도 체크
+            if (section.type === "projects" && Array.isArray(item.outcomes)) {
+                item.outcomes.forEach((outcome: any, oIdx: number) => {
+                    outcomeRequiredFields.forEach((field) => {
+                        if (isEmpty(outcome[field])) {
+                            fieldErrors[`items_${idx}_outcomes_${oIdx}_${field}`] = true;
+                        }
+                    });
+                });
+            }
+        });
+    }
+
+    // 단일 project 섹션의 outcomes도 체크
+    if ("outcomes" in section && Array.isArray(section.outcomes)) {
+        section.outcomes.forEach((outcome: any, idx: number) => {
+            outcomeRequiredFields.forEach((field) => {
+                if (isEmpty(outcome[field])) {
+                    fieldErrors[`outcomes_${idx}_${field}`] = true;
+                }
+            });
+        });
+    }
+
+    return fieldErrors;
+}


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- items 내부 type 필드 제거
- project의 skills 타입 삭제
- 섹션 유효성 검사 로직 리팩토링 및 에러 처리 개선 
- resume의 TextField에 에러 및 helperText props 적용
- 필수값 검증 로직을 utils/validateSectionFields.ts로 분리 및 적용

## 체크리스트
- [x] 코드 리뷰를 완료했습니다.
- [x] 새로운 테스트를 추가하고, 기존 테스트가 통과함을 확인했습니다.
- [ ] 문서를 업데이트했습니다.

## 기타 참고 사항
-