### PR TITLE
refactor:  resume Model의 onDelete를 자식 측으로 이동하고 nullable/cascade 설정 정리

### DIFF
--- a/back-end/src/resume/dto/create-achievements.dto.ts
+++ b/back-end/src/resume/dto/create-achievements.dto.ts
@@ -4,6 +4,8 @@ import { Type } from 'class-transformer';
 import { ResumeBlockType } from '../enum/resume-type.enum';
 
 export class CreateAchievementsDto {
+  @IsEnum(ResumeBlockType)
+  id: ResumeBlockType.ACHIEVEMENTS;
 
   @IsEnum(ResumeBlockType)
   type: ResumeBlockType.ACHIEVEMENTS;

--- a/back-end/src/resume/dto/create-careers.dto.ts
+++ b/back-end/src/resume/dto/create-careers.dto.ts
@@ -1,9 +1,12 @@
-import { IsArray, IsEnum, ValidateNested } from "class-validator";
-import { ResumeBlockType } from "../enum/resume-type.enum";
-import { Type } from "class-transformer";
-import { CreateCareerDto } from "./create-career.dto";
+import { IsArray, IsEnum, ValidateNested } from 'class-validator';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+import { Type } from 'class-transformer';
+import { CreateCareerDto } from './create-career.dto';
 
 export class CreateCareersDto {
+  @IsEnum(ResumeBlockType)
+  id: ResumeBlockType.CAREERS;
+
   @IsEnum(ResumeBlockType)
   type: ResumeBlockType.CAREERS;
 

--- a/back-end/src/resume/dto/create-projects-width-outcomes.dto.ts
+++ b/back-end/src/resume/dto/create-projects-width-outcomes.dto.ts
@@ -4,6 +4,8 @@ import { CreateProjectDto } from './create-project.dto';
 import { ResumeBlockType } from '../enum/resume-type.enum';
 
 export class CreateProjectsWidthOutcomesDto {
+  @IsEnum(ResumeBlockType)
+  id: ResumeBlockType.PROJECTS;
 
   @IsEnum(ResumeBlockType)
   type: ResumeBlockType.PROJECTS;

--- a/back-end/src/resume/dto/create-skills.dto.ts
+++ b/back-end/src/resume/dto/create-skills.dto.ts
@@ -1,9 +1,12 @@
-import { IsEnum, IsArray, ValidateNested } from "class-validator";
-import { Type } from "class-transformer";
-import { ResumeBlockType } from "../enum/resume-type.enum";
-import { CreateSkillDto } from "./create-skill.dto";
+import { IsEnum, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ResumeBlockType } from '../enum/resume-type.enum';
+import { CreateSkillDto } from './create-skill.dto';
 
 export class CreateSkillsDto {
+  @IsEnum(ResumeBlockType)
+  id: ResumeBlockType.SKILLS;
+
   @IsEnum(ResumeBlockType)
   type: ResumeBlockType.SKILLS;
 

--- a/back-end/src/resume/entities/achievement.entity.ts
+++ b/back-end/src/resume/entities/achievement.entity.ts
@@ -16,6 +16,10 @@ export class AchievementModel extends BaseUuidModel {
   @Column({ nullable: true })
   description: string;
 
-  @ManyToOne(() => ResumeModel, (resume) => resume.achievements)
+  @ManyToOne(() => ResumeModel, (resume) => resume.achievements, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: true,
+  })
   resume: ResumeModel;
 }

--- a/back-end/src/resume/entities/career.entity.ts
+++ b/back-end/src/resume/entities/career.entity.ts
@@ -19,6 +19,10 @@ export class CareerModel extends BaseUuidModel {
   @Column()
   description: string;
 
-  @ManyToOne(() => ResumeModel, (resume) => resume.careers)
+  @ManyToOne(() => ResumeModel, (resume) => resume.careers, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: true,
+  })
   resume: ResumeModel;
 }

--- a/back-end/src/resume/entities/custom.entity.ts
+++ b/back-end/src/resume/entities/custom.entity.ts
@@ -10,6 +10,10 @@ export class CustomModel extends BaseUuidModel {
   @Column()
   description: string;
 
-  @ManyToOne(() => ResumeModel, (resume) => resume.customs)
+  @ManyToOne(() => ResumeModel, (resume) => resume.customs, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    nullable: true,
+  })
   resume: ResumeModel;
 }

--- a/back-end/src/resume/entities/introduction.entity.ts
+++ b/back-end/src/resume/entities/introduction.entity.ts
@@ -13,7 +13,10 @@ export class IntroductionModel extends BaseUuidModel {
   @IsString()
   description: string;
 
-  @OneToOne(() => ResumeModel, (resume) => resume.introduction)
+  @OneToOne(() => ResumeModel, (resume) => resume.introduction, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn()
   resume: ResumeModel;
 }

--- a/back-end/src/resume/entities/order.entity.ts
+++ b/back-end/src/resume/entities/order.entity.ts
@@ -19,6 +19,7 @@ export class OrderModel extends BaseUuidModel {
   blockId: string; // 커스텀 블록의 경우에만 사용
 
   @ManyToOne(() => ResumeModel, (resume) => resume.blockOrders, {
+    cascade: true,
     onDelete: 'CASCADE',
   })
   resume: ResumeModel;

--- a/back-end/src/resume/entities/profile.entity.ts
+++ b/back-end/src/resume/entities/profile.entity.ts
@@ -25,7 +25,10 @@ export class ProfileModel extends BaseUuidModel {
   @Column({ nullable: true, name: 'blog_url' })
   blogUrl: string;
 
-  @OneToOne(() => ResumeModel, (resume) => resume.profile)
+  @OneToOne(() => ResumeModel, (resume) => resume.profile, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn()
   resume: ResumeModel;
 }

--- a/back-end/src/resume/entities/project.entity.ts
+++ b/back-end/src/resume/entities/project.entity.ts
@@ -17,7 +17,10 @@ export class ProjectModel extends BaseUuidModel {
   @Column({ nullable: true, name: 'end_date' })
   endDate: Date;
 
-  @ManyToOne(() => ResumeModel, (resume) => resume.projects)
+  @ManyToOne(() => ResumeModel, (resume) => resume.projects, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   resume: ResumeModel;
 
   @OneToMany(() => ProjectOutcomeModel, (outcome) => outcome.project, {

--- a/back-end/src/resume/entities/resume.entity.ts
+++ b/back-end/src/resume/entities/resume.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   OneToMany,
   OneToOne,
+  UpdateDateColumn,
 } from 'typeorm';
 import { IntroductionModel } from './introduction.entity';
 import { SkillModel } from './skill.entity';
@@ -26,16 +27,10 @@ export class ResumeModel extends BaseUuidModel {
   @ManyToOne(() => User, (user) => user.resumes, { onDelete: 'CASCADE' })
   author: User;
 
-  @OneToOne(() => IntroductionModel, (introduction) => introduction.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-  })
+  @OneToOne(() => IntroductionModel, (introduction) => introduction.resume)
   introduction: IntroductionModel;
 
-  @OneToOne(() => ProfileModel, (profile) => profile.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-  })
+  @OneToOne(() => ProfileModel, (profile) => profile.resume)
   profile: ProfileModel;
 
   @ManyToMany(() => SkillModel, (skill) => skill.strongResumes)
@@ -54,36 +49,21 @@ export class ResumeModel extends BaseUuidModel {
   })
   famSkills: SkillModel[];
 
-  @OneToMany(() => ProjectModel, (project) => project.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => ProjectModel, (project) => project.resume)
   projects: ProjectModel[];
 
-  @OneToMany(() => CareerModel, (career) => career.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-    nullable: true,
-  })
+  @OneToMany(() => CareerModel, (career) => career.resume)
   careers: CareerModel[];
 
-  @OneToMany(() => AchievementModel, (achievement) => achievement.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-    nullable: true,
-  })
+  @OneToMany(() => AchievementModel, (achievement) => achievement.resume)
   achievements: AchievementModel[];
 
-  @OneToMany(() => CustomModel, (custom) => custom.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-    nullable: true,
-  })
+  @OneToMany(() => CustomModel, (custom) => custom.resume)
   customs: CustomModel[];
 
-  @OneToMany(() => OrderModel, (blockOrder) => blockOrder.resume, {
-    cascade: true,
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => OrderModel, (blockOrder) => blockOrder.resume)
   blockOrders: OrderModel[];
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/back-end/src/resume/resume.controller.ts
+++ b/back-end/src/resume/resume.controller.ts
@@ -81,7 +81,7 @@ export class ResumeController {
   @Get()
   @UseGuards(AuthenticatedGuard)
   async getAllResumes(@Request() req) {
-    return this.resumeService.getResumes(req.user.id); // 전체 조회
+    return this.resumeService.getResumes(req.user.id);
   }
 
   @Get(':id')
@@ -108,7 +108,7 @@ export class ResumeController {
 
   @Post(':id/introductions')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createIntroduction(
     @Param('id') id: string,
     @Body() createIntroductionDto: CreateIntroductionDto,
@@ -124,7 +124,7 @@ export class ResumeController {
 
   @Post(':id/profiles')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createProfile(
     @Param('id') id: string,
     @Body() profileDto: CreateProfileDto,
@@ -140,7 +140,7 @@ export class ResumeController {
 
   @Post(':id/projects')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createProject(
     @Param('id') id: string,
     @Body() createProjectsDto: CreateProjectsWidthOutcomesDto,
@@ -156,7 +156,7 @@ export class ResumeController {
 
   @Post(':id/skills')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createSkills(
     @Param('id') id: string,
     @Body() createSkillsDto: CreateSkillsDto,
@@ -177,7 +177,7 @@ export class ResumeController {
 
   @Post(':id/achievements')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createAchievements(
     @Param('id') id: string,
     @Body() createAchievementsDto: CreateAchievementsDto,
@@ -193,7 +193,7 @@ export class ResumeController {
 
   @Post(':id/careers')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createCareers(
     @Param('id') id: string,
     @Body() createCareersDto: CreateCareersDto,
@@ -209,7 +209,7 @@ export class ResumeController {
 
   @Post(':id/customs')
   @UseGuards(AuthenticatedGuard)
-  @UseFilters(UpsertResumeEntityDtoFilter) 
+  @UseFilters(UpsertResumeEntityDtoFilter)
   async createCustom(
     @Param('id') id: string,
     @Body() createCustomDto: CreateCustomDto,

--- a/back-end/src/resume/resumeGeneration.Service.ts
+++ b/back-end/src/resume/resumeGeneration.Service.ts
@@ -74,7 +74,7 @@ export class ResumeGenerationService {
       items: projects,
     });
 
-    return this.resumeService.getResumeDetails(resume.id);
+    return await this.resumeService.getResumeDetails(resume.id);
   }
 
   async callResumeCompletion(profileData: string): Promise<string> {


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항

- OneToMany의 onDelete 제거, 자식 ManyToOne/OneToOne(소유자)에 onDelete 적용
- 삭제 전파는 DB FK(onDelete: 'CASCADE') 기준으로 일원화
- FK 보유 측에서만 nullable 관리, 불필요한 nullable 제거

## 체크리스트
- [x] 코드 리뷰를 완료했습니다.


## 기타 참고 사항
- 
