### PR TITLE
feat: GitHub 로그인 시 자동으로 githubUrl 생성 및 저장

### DIFF
--- a/back-end/src/auth/github.strategy.ts
+++ b/back-end/src/auth/github.strategy.ts
@@ -41,11 +41,17 @@ export class GithubStrategy extends PassportStrategy(GitHubStrategy, 'github') {
         `${profile.name?.familyName ?? ''}${profile.name?.givenName ?? ''}` ||
         'GitHub User';
 
+      const githubUsername = profile.username;
+      const githubUrl = githubUsername
+        ? `https://github.com/${githubUsername}`
+        : undefined;
+
       user = await this.userService.findByEmailOrSave(
         email,
         fallbackName,
         Provider.GITHUB,
         encryptedToken,
+        githubUrl,
       );
     } else {
       if (encryptedToken) {

--- a/back-end/src/resume/resumeGeneration.Service.ts
+++ b/back-end/src/resume/resumeGeneration.Service.ts
@@ -71,7 +71,7 @@ export class ResumeGenerationService {
       email: user.email,
       phoneNumber: user.phoneNumber,
       education: user.educationLevel,
-      githubUrl: `https://github.com/${user.githubUrl}`,
+      githubUrl: `${user.githubUrl}`,
       blogUrl: user.blogUrl,
     });
 

--- a/back-end/src/user/dto/update-user.dto.ts
+++ b/back-end/src/user/dto/update-user.dto.ts
@@ -1,4 +1,11 @@
-import { IsDate, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsDate,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+} from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ValidateLength } from 'src/common/decorator/validate-length.decorator';
 
@@ -17,7 +24,8 @@ export class UpdateUserDto {
   @IsOptional()
   phoneNumber?: number;
 
-  @IsString()
+  @IsUrl()
+  @Matches(/^https:\/\/github\.com\/.+$/)
   @IsOptional()
   githubUrl?: string;
 

--- a/back-end/src/user/user.service.ts
+++ b/back-end/src/user/user.service.ts
@@ -78,9 +78,10 @@ export class UserService {
     name: string,
     provider: Provider,
     githubAccessToken?: string,
+    githubUrl?: string,
   ): Promise<User> {
     await this.userRepository.upsert(
-      { email, name, provider, githubAccessToken },
+      { email, name, provider, githubAccessToken, githubUrl },
       {
         conflictPaths: ['email'],
         skipUpdateIfNoValuesChanged: true,

--- a/front-end/src/page/MainBodyPage.tsx
+++ b/front-end/src/page/MainBodyPage.tsx
@@ -74,7 +74,6 @@ export const MainBodyPage = () => {
   const MotionUserCard = motion.create(UserCard);
   const MotionStartButton = motion.create(StartButton);
   const row1 = [
-    "이런건 비싸겠지..?",
     "하… 취업 어렵다…",
     "면접 준비는 어떡하지..",
     "다른 지원자들은 어떤 자격증이 있으려나?",
@@ -96,20 +95,21 @@ export const MainBodyPage = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 1 }}
             >
-              코드를 기록했다면,
+              개발자의 성장을,
               <br />
-              이젠 보여줄 차례
+              데이터로 증명하세요
               <br />
-              자동생성 <span>AI 포트폴리오</span>
+              <span>AI 기반 포트폴리오</span>
             </motion.h1>
             <motion.p
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 1, delay: 0.3 }}
             >
-              더 이상 이력서와 포트폴리오 작성에 시간을 낭비하지 마세요.
+              GitHub 활동을 분석해 전문적인 이력서와 포트폴리오를 자동으로
+              생성합니다.
               <br />
-              AI가 당신의 개발 커리어를 기록해드립니다.
+              개발에 집중하고, 나머지는 AI에게 맡기세요.
             </motion.p>
             <MotionStartButton
               whileHover={{ scale: 1.05 }}

--- a/front-end/src/page/UserPage.tsx
+++ b/front-end/src/page/UserPage.tsx
@@ -359,7 +359,7 @@ const AccountSection = memo(
               <div css={labelStyle}>
                 GitHub
                 <CustomTextField
-                  label="github.com/"
+                  label="https://github.com/username"
                   value={userData.githubUrl}
                   onChange={(value) => changeValue("githubUrl", value)}
                 />
@@ -647,6 +647,12 @@ export const UserPage = () => {
     []
   );
 
+  const getGithubUsername = useCallback((url: string) => {
+    if (!url) return null;
+    const match = url.match(/github\.com\/([^\/]+)/);
+    return match ? match[1] : null;
+  }, []);
+
   // Suspense로 데이터 로딩 처리
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -669,7 +675,9 @@ export const UserPage = () => {
               >
                 <StatsTitle>🌱 GitHub Activity</StatsTitle>
                 <img
-                  src={`https://ghchart.rshah.org/${userData.githubUrl}`}
+                  src={`https://ghchart.rshah.org/${getGithubUsername(
+                    userData.githubUrl
+                  )}`}
                   alt="GitHub Contributions"
                   loading="lazy"
                   css={css`


### PR DESCRIPTION
## 관련 이슈
- 

## 변경 사항
- GitHub 로그인 시 profile.username으로 githubUrl 자동 생성
- 새 사용자 생성 시 https://github.com/{username} 형식으로 저장
- UpdateUserDto에 GitHub URL 유효성 검사 추가
- UserPage에서 GitHub Activity 차트에 username만 사용하도록 수정

## 체크리스트
- [x] 코드 리뷰를 완료했습니다.


## 기타 참고 사항
- 
